### PR TITLE
Fix Fortran comments in .F files from recent commits

- fix typo 'Compressureute' -> 'Compute' in fail_biquad_s.F
- fix typo 'tretra10' -> 'tetra10' and expand 'w/' to 'with' in starter0.F
- capitalise lowercase sentence-starting comments in fail_biquad_c.F,
  fail_biquad_s.F and grid2mat.F (8 occurrences)
- improve wording of IREG=2/3 description in hm_read_fail_biquad.F:
  clarify 'swift function' as 'Swift hardening function'
- rephrase informal 'nothing here' comment in execargcheck.F
- remove dead commented-out MSQ lines in qinit2.F and q4init2.F



### DIFF
--- a/engine/source/materials/fail/biquad/fail_biquad_c.F
+++ b/engine/source/materials/fail/biquad/fail_biquad_c.F
@@ -179,7 +179,7 @@ C-----------------------------------------------
            REG_FAC(1:NEL) = UVAR(1:NEL,9)
          ENDIF
        ENDIF
-       ! calculate triaxiality
+       ! Calculate triaxiality
          do i=1,nel
            pressure = (signxx(I)+ signyy(I)) * third
            svm      = sqrt((signxx(I)**2)+(signyy(I)**2)-(signxx(I)*signyy(I))+(THREE*SIGNXY(I)**2))
@@ -188,7 +188,7 @@ C-----------------------------------------------
          end do
 !
        IF (IREG > 1) THEN
-         ! calculate scaling factor on failure limits depending on triaxiality
+         ! Calculate scaling factor on failure limits depending on triaxiality
          ipos(1:nel,1) = 1
          call table_mat_vinterp(fail%table4d(1),nel,nel,ipos,eta,regf_eta,deri)
          reg_fac(1:nel) = (one - regf_eta(1:nel)) + regf_eta(1:nel)*reg_fac(1:nel)

--- a/engine/source/materials/fail/biquad/fail_biquad_s.F
+++ b/engine/source/materials/fail/biquad/fail_biquad_s.F
@@ -125,7 +125,7 @@ C===============================================================================
         ENDIF
       ENDIF
 !---------------------------------------------------------------------------------------------------
-       ! calculate triaxiality
+       ! Calculate triaxiality
        do i=1,nel
           pressure = (signxx(I) + signyy(I) + signzz(I)) * third
           sxx = signxx(I) - pressure
@@ -134,14 +134,14 @@ C===============================================================================
           svm = half*(sxx**2 + syy**2 + szz**2) + signxy(I)**2 + signzx(I)**2 + signyz(I)**2
           svm = sqrt(three*svm)
 !
-          ! Compressureute stress triaxiality
+          ! Compute stress triaxiality
           triax = pressure / max(em20,svm)
           triax = max(triax, -two_third)
           triax = min(triax,  two_third)
           eta(i,1) = triax
        end do
        IF (IREG > 1) THEN
-         ! calculate triaxiality dependent scaling factor on failure limits
+         ! Calculate triaxiality-dependent scaling factor on failure limits
          ipos(1:nel,1) = 1
          call table_mat_vinterp(fail%table4d(1),nel,nel,ipos,eta,regf_eta,deri)
          reg_fac(1:nel) = (one - regf_eta(1:nel)) + regf_eta(1:nel)*reg_fac(1:nel)

--- a/starter/source/elements/solid_2d/quad/qinit2.F
+++ b/starter/source/elements/solid_2d/quad/qinit2.F
@@ -195,7 +195,6 @@ c
           ENDIF
         ENDIF
         DTELEM(NFT+I)=DTX(I)
-!        MSQ(NFT+I) = FOURTH * PM(89,MAT(I))*AIRE(I) ! nodal mass in engine->fac=V/a
         STI = HALF * PM(89,MAT(I))*GBUF%VOL(I) / MAX(EM20,DTX(I)*DTX(I)) ! =fac*sti(engine)
         MAS = PM(89,MAT(I))*AIRE(I)
         IP = IPARTQ(NFT+I)

--- a/starter/source/elements/solid_2d/quad4/q4init2.F
+++ b/starter/source/elements/solid_2d/quad4/q4init2.F
@@ -339,7 +339,6 @@ C-------------------------------------------
           ENDIF
         ENDIF
        DTELEM(NFT+I)=DTX(I)
-!        MSQ(NFT+I) = FOURTH * PM(89,MAT(I))*AREA(I) ! nodal mass (engine)
         STI = HALF * PM(89,MAT(I))*GBUF%VOL(I) / MAX(EM20,DTX(I)*DTX(I))
         MAS = PM(89,MAT(I))*AREA(I)
         IP = IPARTQ(NFT+I)

--- a/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
+++ b/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
@@ -146,8 +146,8 @@ c
       ELSE IF (IREG == 0) THEN
         IREG = 1
       END IF
-      ! IREG = 2 => automatic correction of element size scaling factor depending on triaxiality
-      ! IREG = 3 => IREG = 2 with debug output of generated tabulated swift function
+      ! IREG = 2 => Automatic scaling of the element size factor based on triaxiality
+      ! IREG = 3 => Same as IREG = 2, with debug output of the generated tabulated Swift hardening function
 c---------------------------------------------------
 c     pre definition for user-input data when only 
 c     tension test data are provided

--- a/starter/source/spmd/domain_decomposition/grid2mat.F
+++ b/starter/source/spmd/domain_decomposition/grid2mat.F
@@ -634,7 +634,7 @@ C We have to tag elements for know theirs number of nodes
             L = L + 1
             ELEM_COORDS(:,I) = ELEM_COORDS(:,I) + X(:,N)
           END IF
-          ! center of the element
+          ! Center of the element
           ELEM_COORDS(:,I) = ELEM_COORDS(:,I) / REAL(L)
         ENDDO 
       ENDDO
@@ -666,7 +666,7 @@ C
           ADSKY(N) = ADSKY(N) + 1
           ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) + X(:,N)
         ENDDO
-        ! center of the element
+        ! Center of the element
         ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) / 4.0
       ENDDO
 C
@@ -682,7 +682,7 @@ C
           ADSKY(N) = ADSKY(N) + 1
           ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) + X(:,N)
         ENDDO
-        ! center of the element
+        ! Center of the element
         ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) / 4.0
       ENDDO
 C     
@@ -699,7 +699,7 @@ C
           ADSKY(N) = ADSKY(N) + 1
           ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) + X(:,N)
         ENDDO
-        ! center of the element
+        ! Center of the element
         ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) / 2.0
        ENDDO
 C
@@ -715,7 +715,7 @@ C
           ADSKY(N) = ADSKY(N) + 1
           ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) + X(:,N)
         ENDDO
-        ! center of the element
+        ! Center of the element
         ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) / 2.0
       ENDDO
 C
@@ -731,7 +731,7 @@ C
           ADSKY(N) = ADSKY(N) + 1
           ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) + X(:,N)
         ENDDO
-        ! center of the element
+        ! Center of the element
         ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) / 2.0
         IF(NINT(GEO(12,IXR(1,I)))==12) THEN
           N = IXR(4,I)
@@ -752,7 +752,7 @@ C
           ADSKY(N) = ADSKY(N) + 1
           ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) + X(:,N)
         ENDDO
-        ! center of the element
+        ! Center of the element
         ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) / 3.0
       ENDDO
 C
@@ -773,7 +773,7 @@ C
           ADSKY(N) = ADSKY(N) + 1
           ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) + X(:,N)
         ENDDO
-        ! center of the element
+        ! Center of the element
         ELEM_COORDS(:,I+OFF) = ELEM_COORDS(:,I+OFF) / REAL(NELX)
       ENDDO
 C

--- a/starter/source/starter/execargcheck.F
+++ b/starter/source/starter/execargcheck.F
@@ -319,7 +319,7 @@ C------------------------------------------------
                 OUTPUT%CHECKSUM%ST_CHECKSUM_READ = 1
                 IF (PCHECKSUMI==0) PCHECKSUMI = I
             CASE ( '-METIS_SEED') 
-               ! nothing here, called again in grid2mat
+               ! No action here; argument is processed again in grid2mat
             CASE DEFAULT
             ! ------------------------------------------------
             ! unknown command line argument

--- a/starter/source/starter/starter0.F
+++ b/starter/source/starter/starter0.F
@@ -789,7 +789,7 @@ C Add RBODY master node if not existing in /RBODY cards
 C------------------------------------------------------------------
       CALL hm_rbodies_add_main_node(LSUBMODEL)
 C-------------------------------------------------------------------
-C itetra4=1: convert tetra4 to tretra10 w/ itetra10=2
+C itetra4=1: Convert tetra4 to tetra10 with itetra10=2
 C------------------------------------------------------------------
       itetra4=1
       CALL hm_convert_tetra4_to_tetra10(itetra4) 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
