### PR TITLE
Fix typos in comments across multiple source files

### DIFF
--- a/engine/source/coupling/cwipi_coupling_adapter.cpp
+++ b/engine/source/coupling/cwipi_coupling_adapter.cpp
@@ -168,7 +168,7 @@ bool CwipiCouplingAdapter::configure(const std::string& configFile) {
 
 void CwipiCouplingAdapter::setNodes(const std::vector<int>& nodeIds) {
     couplingNodeIds_ = nodeIds;
-    //pritn nodes IDs    std::cout << "Setting coupling node IDs for CWIPI coupling adapter: ";
+    //print nodes IDs    std::cout << "Setting coupling node IDs for CWIPI coupling adapter: ";
 //    std::cout << "Coupling node IDs for CWIPI coupling adapter: ";
 //    for (int nodeId : couplingNodeIds_) {
 //        std::cout << nodeId << " ";

--- a/engine/source/elements/sh3n/coque3n/c3coef3.F
+++ b/engine/source/elements/sh3n/coque3n/c3coef3.F
@@ -85,7 +85,7 @@ C --- A CORRIGER : VOL00(I) = THK0(I)*AREA0(I)
 C
       IF (MTN == 19) THEN
         VISCDEF=FOURTH
-      ELSEIF (MTN == 25 .OR. MTN == 27 .OR. MTN == 123 .OR. MTN == 125 .OR. MTN == 127 .OR. MTN == 132) THEN ! must be rechecked for type51,17, 11, pcommp
+      ELSEIF (MTN == 25 .OR. MTN == 27 .OR. MTN == 123 .OR. MTN == 125 .OR. MTN == 127 .OR. MTN == 132) THEN ! must be rechecked for type51,17, 11, pcompp
         VISCDEF=FIVEEM2
       ELSE
         VISCDEF=ZERO

--- a/engine/source/materials/fail/biquad/fail_biquad_s.F
+++ b/engine/source/materials/fail/biquad/fail_biquad_s.F
@@ -134,7 +134,7 @@ C===============================================================================
           svm = half*(sxx**2 + syy**2 + szz**2) + signxy(I)**2 + signzx(I)**2 + signyz(I)**2
           svm = sqrt(three*svm)
 !
-          ! Compressureute stress triaxiality
+          ! Compute stress triaxiality
           triax = pressure / max(em20,svm)
           triax = max(triax, -two_third)
           triax = min(triax,  two_third)

--- a/engine/source/materials/mat/mat125/strainrate_dependency_125c.F90
+++ b/engine/source/materials/mat/mat125/strainrate_dependency_125c.F90
@@ -180,7 +180,7 @@
               ems(1:nel)= yy(1:nel)
               vartmp(:,15)=ipos(:,1)
         end if
-          ! shear strengh sc
+          ! shear strength sc
         ifunc(16) = matparam%table(16)%notable
         if(ifunc(16) /= 0) then  ! sc
              ipos(:,1) = vartmp(:,16)

--- a/engine/source/materials/mat/mat125/strainrate_dependency_125s.F90
+++ b/engine/source/materials/mat/mat125/strainrate_dependency_125s.F90
@@ -218,7 +218,7 @@
               ems(1:nel)= yy(1:nel)
               vartmp(:,15)=ipos(:,1)
         end if
-          ! shear strengh sc
+          ! shear strength sc
         ifunc(16) = matparam%table(16)%notable
         if(ifunc(16) /= 0) then  ! sc
              ipos(:,1) = vartmp(:,16)
@@ -250,7 +250,7 @@
               ems13(1:nel)= yy(1:nel)
               vartmp(:,19)=ipos(:,1)
           end if
-          ! shear strengh sc13
+          ! shear strength sc13
           ifunc(20) = matparam%table(20)%notable
           if(ifunc(20) /= 0) then  ! sc
               ipos(:,1) = vartmp(:,20)
@@ -282,7 +282,7 @@
               ems23(1:nel)= yy(1:nel)
               vartmp(:,23)=ipos(:,1)
            end if
-          ! shear strengh sc13
+          ! shear strength sc23
           ifunc(24) = matparam%table(24)%notable
           if(ifunc(24)/= 0) then  ! sc
             ipos(:,1) = vartmp(:,24)

--- a/engine/source/materials/mat/mat132/rate_dependency_parameters.F90
+++ b/engine/source/materials/mat/mat132/rate_dependency_parameters.F90
@@ -105,7 +105,7 @@
           xt(1:nel) = yy(1:nel)
           vartmp(:,2)=ipos(:,1)
         endif   !
-       ! xc rate computaion
+       ! xc rate computation
         func= matparam%table(3)%notable
         if(func/= 0) then
           ipos(:,1) = vartmp(:,3)
@@ -180,7 +180,7 @@
           xt0(1:nel) = yy(1:nel)
           vartmp(:,12)=ipos(:,1)
         endif   !
-       ! xc0 rate computaion
+       ! xc0 rate computation
         func= matparam%table(13)%notable
         if(func/= 0) then
           ipos(:,1) = vartmp(:,13)

--- a/engine/source/materials/mat/mat132/sigeps132c.F90
+++ b/engine/source/materials/mat/mat132/sigeps132c.F90
@@ -165,14 +165,14 @@
           nu13  = mat_param%uparam(9)
           nu23 = mat_param%uparam(11)
           !! nu32 = mat_param%uparam(12)
-          ! strengh direction
-          xt_1(1:nel)     = mat_param%uparam(13) ! initial strengh fiber tension
-          xc_1(1:nel)     = mat_param%uparam(14) ! initial strengh fiber compression
-          yt_1(1:nel)     = mat_param%uparam(15) ! initial strengh transverse tension
-          yc_1(1:nel)     = mat_param%uparam(16)  ! initial strengh transverse compression
-          sl_1(1:nel)     = mat_param%uparam(17)  ! initial shear strengh
-          xt0_1(1:nel)    = mat_param%uparam(18)  ! initial strengh tension fiber for bilinear damage
-          xc0_1(1:nel)    = mat_param%uparam(19)  ! initial strengh compression fiber for bilinear damage
+          ! strength direction
+          xt_1(1:nel)     = mat_param%uparam(13) ! initial strength fiber tension
+          xc_1(1:nel)     = mat_param%uparam(14) ! initial strength fiber compression
+          yt_1(1:nel)     = mat_param%uparam(15) ! initial strength transverse tension
+          yc_1(1:nel)     = mat_param%uparam(16)  ! initial strength transverse compression
+          sl_1(1:nel)     = mat_param%uparam(17)  ! initial shear strength
+          xt0_1(1:nel)    = mat_param%uparam(18)  ! initial strength tension fiber for bilinear damage
+          xc0_1(1:nel)    = mat_param%uparam(19)  ! initial strength compression fiber for bilinear damage
           !
           gxt_1(1:nel)     = mat_param%uparam(20)
           gxc_1(1:nel)     = mat_param%uparam(21)
@@ -210,7 +210,7 @@
           eta_t           = mat_param%uparam(54)
           st_1(1:nel)     = mat_param%uparam(55)
           phic_1(1:nel)   = mat_param%uparam(56) ! misalignment angle at fiber compression
-          g_ratio_1(1:nel) = mat_param%uparam(57) ! GII/GI strengh ratio
+          g_ratio_1(1:nel) = mat_param%uparam(57) ! GII/GI strength ratio
           ratio   = mat_param%uparam(58 )
           !
           inv_det = one/(one - nu12*nu21)
@@ -339,13 +339,13 @@
             ! Build undamaged compliance matrix H0 (plane stress)
             ! Using Eq. 5 with d1=d2=d6=0
             ! Calculate effective stress σ̃ = H0⁻¹ : ε
-            ! For plane stres s(σ33 = 0), we have:
+            ! For plane stress (σ33 = 0), we have:
             ! ε11 = (σ̃11/E1) - (ν12*σ̃22/E1) + α11ΔT + β11ΔM
             ! ε22 = - (ν21*σ̃11/E2) + (σ̃22/E2) + α22ΔT + β22ΔM
             ! γ12 = σ̃12/G12
             sigma_a   =   inv_det*(e1*epsxx(i)     + nu21*e1*epsyy(i))
             sigma_b   =   inv_det*(nu12*e2*epsxx(i)+ e2*epsyy(i))
-            tau_ab    =   signxy(i) ! g12*epsxy(i)  ! sugnxy using function ?
+            tau_ab    =   signxy(i) ! g12*epsxy(i)  ! signxy using function ?
             tau_ca    =   shf(i)*g13*epszx(i)
             tau_bc    =   shf(i)*g23*epsyz(i)
             !!sigma_c   = zero  ! normal condition

--- a/starter/source/materials/fail/tabulated/hm_read_fail_tab2.F
+++ b/starter/source/materials/fail/tabulated/hm_read_fail_tab2.F
@@ -196,7 +196,7 @@ C     Filling buffer tables
     !          NUVAR( 4) : Stores position1 of table interpolation "Compute the element size regularization factor"
     !          NUVAR( 5) : Stores position2 
     !          NUVAR( 6) : Stores position3
-    !          NUVAR( 7) : Stores position if interpolation function Compute the strain rate dependency factor
+    !          NUVAR( 7) : Stores position for interpolation function computing the strain rate dependency factor
     !          NUVAR( 8) : Stores position 1 of table interpolation "COMPUTATION OF PLASTIC STRAIN AT FAILURE
     !          NUVAR( 9) : Stores position 2
     !          NUVAR(10) : Stores position 3

--- a/starter/source/materials/mat/mat125/hm_read_mat125.F90
+++ b/starter/source/materials/mat/mat125/hm_read_mat125.F90
@@ -386,7 +386,7 @@
           if(erods == zero) erods= ep10
           if(gammar <= zero) gammar = ep10
           if(gammaf <= zero) gammaf = two*ep10
-          ! our of plane damage used in shell
+          ! out of plane damage used in shell
           if(tsdm <= zero ) tsdm = zep9
 !
           ! default strain rate cutoff frequency

--- a/starter/source/materials/mat/mat132/hm_read_mat132.F90
+++ b/starter/source/materials/mat/mat132/hm_read_mat132.F90
@@ -130,13 +130,13 @@
       call hm_get_floatv('LSDYNA_PRBA'  ,nu21     ,is_available, lsubmodel, unitab)
       call hm_get_floatv('LSDYNA_PRCB'  ,nu32     ,is_available, lsubmodel, unitab)
       call hm_get_floatv('LSDYNA_PRCA'  ,nu31     ,is_available, lsubmodel, unitab) 
-!card5 strenght energy 
+!card5 strength energy 
       call hm_get_floatv  ('LSD_GXC'       ,gxc         ,is_available, lsubmodel, unitab)
       call hm_get_floatv  ('LSD_GXT'       ,gxt         ,is_available, lsubmodel, unitab)
       call hm_get_floatv  ('LSD_GYC'       ,gyc         ,is_available, lsubmodel, unitab)
       call hm_get_floatv  ('LSD_GYT'       ,gyt         ,is_available, lsubmodel, unitab)
       call hm_get_floatv  ('LSD_GSL'       ,gsl         ,is_available, lsubmodel, unitab)      
-!card6 strenght 
+!card6 strength 
       call hm_get_floatv  ('LSD_MAT_XT'       ,xt         ,is_available, lsubmodel, unitab)
       call hm_get_floatv  ('LSD_MAT_XC'       ,xc         ,is_available, lsubmodel, unitab)
       call hm_get_floatv  ('LSD_MAT_YT'       ,yt         ,is_available, lsubmodel, unitab)

--- a/starter/source/model/sets/create_line_from_ext_surface_ext_all.F
+++ b/starter/source/model/sets/create_line_from_ext_surface_ext_all.F
@@ -226,7 +226,7 @@ C-----------------------------------------------
         ENDIF
       ENDIF ! IF (IEXT == 2)
 !------------------
-!     add already exixting 1D - element lines
+!     add already existing 1D - element lines
 !------------------
       IF (GO_IN_ARRAY .EQV. .TRUE.) THEN
         DO I=1+NSEG,NSEG+DELBUF%SZ_LINE


### PR DESCRIPTION
- "Compressureute" -> "Compute" in fail_biquad_s.F
- "strengh" -> "strength" in strainrate_dependency_125c/s.F90, sigeps132c.F90, hm_read_mat132.F90
- "strenght" -> "strength" in hm_read_mat132.F90 (card5/card6 comments)
- "shear strengh sc13" -> "shear strength sc23" (also wrong variable name) in strainrate_dependency_125s.F90
- "stres s" -> "stress" in sigeps132c.F90
- "sugnxy" -> "signxy" in sigeps132c.F90
- "computaion" -> "computation" in rate_dependency_parameters.F90
- "our of plane" -> "out of plane" in hm_read_mat125.F90
- "pritn" -> "print" in cwipi_coupling_adapter.cpp
- "pcommp" -> "pcompp" in c3coef3.F
- "exixting" -> "existing" in create_line_from_ext_surface_ext_all.F
- "Stores position if interpolation" -> "Stores position for interpolation" in hm_read_fail_tab2.F

https://claude.ai/code/session_015MtHjYBzDi9Eu46FSmHqu9