### PR TITLE
engine: add NVIDIA HPC SDK (nvfortran/nvc) CMake compiler config

### DIFF
--- a/engine/CMake_Compilers/cmake_linux64_nvidia.txt
+++ b/engine/CMake_Compilers/cmake_linux64_nvidia.txt
@@ -1,0 +1,254 @@
+########################################
+#  ENGINE - NVIDIA HPC SDK COMPILER
+#  nvfortran / nvc / nvc++
+#########################################
+
+
+# General machine flag setting
+set ( cppmach "-DCPP_mach=CPP_p4linux964" )
+set ( cpprel  "-DCPP_rel=80" )
+
+
+# MPI
+# ---
+if ( DEFINED MPI )
+  set ( mpiver "${MPI}" )
+  if ( mpiver STREQUAL "smp")
+     set (mpi_suf "" )
+  elseif ( mpiver STREQUAL "ompi")
+
+      set (mpi_inc "-I/opt/openmpi/include/")
+      set (mpi_lib "-L/opt/openmpi/lib -lmpi -lmpi_mpifh" )
+
+    if (mpi_os STREQUAL "1")
+
+      set (mpi_inc " ")
+      set (mpi_lib "-lmpi -lmpi_mpifh" )
+    else()
+      if ( DEFINED mpi_root )
+        set (mpi_inc "-I${mpi_root}/include/")
+        set (mpi_lib "-L${mpi_root}/lib -lmpi -lmpi_mpifh" )
+      else()
+        set (mpi_inc "-I/opt/openmpi/include/")
+        set (mpi_lib "-L/opt/openmpi/lib -lmpi -lmpi_mpifh" )
+
+        if ( DEFINED mpi_incdir )
+            set (mpi_inc "-I${mpi_incdir}")
+        endif()
+        if ( DEFINED mpi_libdir )
+            set (mpi_lib "-L${mpi_libdir} -lmpi -lmpi_mpifh")
+        endif()
+
+      endif()
+    endif()
+
+    set (mpi_suf "_${mpiver}" )
+    set (mpi_flag "-DMPI ${mpi_inc}")
+  else()
+    message( FATAL_ERROR "\n ERROR : -mpi=${mpiver} not available for this platform\n\n" )
+  endif()
+endif ()
+
+set ( RELNAME ${arch}${mpi_suf} )
+
+
+# Third party libraries
+# ---------------------
+
+#H3D
+set (h3d_inc "-I${source_directory}/../extlib/h3d/includes")
+
+#ZLIB
+set (zlib_inc "-I${source_directory}/../extlib/zlib/linux64/include")
+set (zlib_lib "${source_directory}/../extlib/zlib/linux64/lib/libz.a")
+
+# MD5
+set (md5_inc "-I${source_directory}/../extlib/md5/include")
+set (md5_lib "${source_directory}/../extlib/md5/linux64/libmd5.a")
+
+# Note: MUMPS implicit solver is not supported with the NVIDIA compiler
+
+
+#
+# compiler Flags
+# --------------
+set (CMAKE_Fortran_FLAGS " " )
+set (CMAKE_C_FLAGS " " )
+set (CMAKE_CPP_FLAGS " " )
+set (CMAKE_CXX_FLAGS " " )
+
+set (CMAKE_Fortran_FLAGS_DEBUG " " )
+set (CMAKE_Fortran_FLAGS_RELEASE " " )
+
+set (CMAKE_C_FLAGS_DEBUG " " )
+set (CMAKE_C_FLAGS_RELEASE " " )
+
+set (CMAKE_CPP_FLAGS_DEBUG " " )
+set (CMAKE_CPP_FLAGS_RELEASE " " )
+
+set (CMAKE_CXX_FLAGS_DEBUG " " )
+set (CMAKE_CXX_FLAGS_RELEASE " " )
+
+
+# Single / Double Precision
+# -------------------------
+if (precision STREQUAL "sp")
+  set (precision_flag "-DMYREAL4")
+else (precision STREQUAL "sp")
+  set (precision_flag "-DMYREAL8")
+endif (precision STREQUAL "sp")
+
+
+# Modules directory
+# nvfortran uses -module instead of -J
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/CMakeFiles/modules )
+set(CMAKE_Fortran_MODDIR_FLAG "-module " )
+
+message (STATUS "modules: ${CMAKE_Fortran_MODULE_DIRECTORY}")
+
+
+#---------------------------
+# Generic Compilation flags
+#---------------------------
+
+# Linear algebra (MUMPS not supported for NVIDIA compiler)
+set ( wo_linalg "-DWITHOUT_LINALG" )
+
+# NVIDIA HPC SDK intrinsic modules path.
+# Override by setting the NVHPC environment variable to the versioned SDK root,
+# e.g. export NVHPC=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7
+set( nv_sdk_inc "/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/include")
+if (DEFINED ENV{NVHPC})
+  set( nv_sdk_inc "$ENV{NVHPC}/compilers/include")
+endif()
+
+# Base Fortran flags common to all build modes:
+#   -mp            OpenMP threading
+#   -Mnofma        Disable fused multiply-add (floating-point reproducibility)
+#   -Mextend       Allow 132-column fixed-form source lines
+#   -Mnostdinc     Do not search standard include paths (explicit path added below)
+#   -traceback     Generate traceback info for runtime errors
+#   -Munroll       Enable loop unrolling
+#   -Mvect=simd    Enable SIMD vectorization
+#   -Minform=warn  Report warnings and above
+set( fort_flags "-Mnofma -mp -traceback -Mextend -Mnostdinc -Munroll -Mvect=simd -Minform=warn -module ${nv_sdk_inc}")
+
+
+if ( debug STREQUAL "1" )
+
+# Fortran (debug)
+set_source_files_properties( ${source_files} PROPERTIES COMPILE_FLAGS
+  "-Wall -g -O0 -Mbounds ${fort_flags} ${wo_linalg} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_NVFORTRAN=1 ${mpi_flag} ${ADF}" )
+
+# C source files
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS
+  "-g -O0 -mp ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} ${mpi_flag}" )
+
+# CXX source files
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS
+  "-g -O0 -mp ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} -std=c++14 ${mpi_flag}" )
+
+else ()
+
+# Fortran (optimized)
+set_source_files_properties( ${source_files} PROPERTIES COMPILE_FLAGS
+  "-O2 ${fort_flags} ${wo_linalg} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_NVFORTRAN=1 ${mpi_flag} ${ADF}" )
+
+# C source files
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS
+  "-w -O2 -mp ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} ${mpi_flag}" )
+
+# CXX source files
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS
+  "-w -O2 -mp ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} -std=c++14 ${mpi_flag}" )
+
+endif()
+
+
+# Linking flags
+set (CMAKE_EXE_LINKER_FLAGS "-Wl,--export-dynamic -Wl,-no-pie -mp" )
+string(STRIP ${CMAKE_EXE_LINKER_FLAGS} CMAKE_EXE_LINKER_FLAGS)
+
+# Libraries
+if ( static_link STREQUAL "1" )
+  set (LINK "rt ${zlib_lib} ${md5_lib} ${mpi_lib} -ldl -Bstatic_pgi -Bstatic_c++libs" )
+else()
+  set (LINK "rt ${zlib_lib} ${md5_lib} ${mpi_lib} -ldl" )
+endif()
+string(STRIP ${LINK} LINK)
+
+
+# -------------------------------------------------------------------------------------------------------------------------------------------
+# Specific per-file compilation flags
+
+if( no_python STREQUAL "1" )
+  get_source_file_property( existing_flags ${source_directory}/../common_source/modules/cpp_python_funct.cpp COMPILE_FLAGS)
+  set_source_files_properties( ${source_directory}/../common_source/modules/cpp_python_funct.cpp PROPERTIES COMPILE_FLAGS "${existing_flags} -DPYTHON_DISABLED" )
+endif()
+
+
+if ( NOT debug STREQUAL "1" )
+
+set (F_O0_compiler_flags "-O0 ${fort_flags} ${wo_linalg} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_NVFORTRAN=1 ${mpi_flag} ${ADF}")
+set (F_O1_compiler_flags "-O1 ${fort_flags} ${wo_linalg} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_NVFORTRAN=1 ${mpi_flag} ${ADF}")
+set (F_O2_compiler_flags "-O2 ${fort_flags} ${wo_linalg} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_NVFORTRAN=1 ${mpi_flag} ${ADF}")
+set (C_O1_compiler_flags "-O1 -mp ${precision_flag} ${cppmach} ${cpprel} ${zlib_inc} ${md5_inc} ${mpi_flag} ${ADF}")
+
+# resol_init.F
+set_source_files_properties( ${source_directory}/source/engine/resol_init.F PROPERTIES COMPILE_FLAGS ${F_O1_compiler_flags} )
+
+# resol.F
+set_source_files_properties( ${source_directory}/source/engine/resol.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# arralloc.F
+set_source_files_properties( ${source_directory}/source/output/restart/arralloc.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# m1lawp.F
+set_source_files_properties( ${source_directory}/source/materials/mat/mat001/m1lawp.F PROPERTIES COMPILE_FLAGS ${F_O1_compiler_flags} )
+
+# cbasumg3.F
+set_source_files_properties( ${source_directory}/source/elements/shell/coqueba/cbasumg3.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# redkey0.F
+set_source_files_properties( ${source_directory}/source/input/redkey0.F PROPERTIES COMPILE_FLAGS ${F_O1_compiler_flags} )
+
+# i3fri3.F
+set_source_files_properties( ${source_directory}/source/interfaces/inter3d/i3fri3.F PROPERTIES COMPILE_FLAGS ${F_O1_compiler_flags} )
+
+# dsgri7.F
+set_source_files_properties( ${source_directory}/source/implicit/dsolve/dsgri7.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# i11cor3.F
+set_source_files_properties( ${source_directory}/source/interfaces/int11/i11cor3.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# i11pen3.F
+set_source_files_properties( ${source_directory}/source/interfaces/int11/i11pen3.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# i7cor3t.F
+set_source_files_properties( ${source_directory}/source/interfaces/int07/i7cor3t.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# i20cor3.F
+set_source_files_properties( ${source_directory}/source/interfaces/int20/i20cor3.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# i20sto.F
+set_source_files_properties( ${source_directory}/source/interfaces/intsort/i20sto.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# i23cort3.F
+set_source_files_properties( ${source_directory}/source/interfaces/int23/i23cort3.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# i24cort3.F
+set_source_files_properties( ${source_directory}/source/interfaces/int24/i24cort3.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# i25cort3.F
+set_source_files_properties( ${source_directory}/source/interfaces/int25/i25cort3.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# spbuc3.F
+set_source_files_properties( ${source_directory}/source/elements/sph/spbuc3.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# spclasv.F
+set_source_files_properties( ${source_directory}/source/elements/sph/spclasv.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags} )
+
+# rad2rad_c.c
+set_source_files_properties( ${source_directory}/source/coupling/rad2rad/rad2rad_c.c PROPERTIES COMPILE_FLAGS ${C_O1_compiler_flags} )
+
+endif()

--- a/engine/CMake_Compilers/cmake_linux64_nvidia_compilers.sh
+++ b/engine/CMake_Compilers/cmake_linux64_nvidia_compilers.sh
@@ -1,0 +1,5 @@
+# Fixed compiler switches for linux64 NVIDIA HPC SDK binary
+Fortran_comp=nvfortran
+C_comp=nvc
+CXX_comp=nvc++
+CPP_comp=nvc++

--- a/engine/CMake_Compilers/platforms.txt
+++ b/engine/CMake_Compilers/platforms.txt
@@ -10,6 +10,8 @@
          -arch=linux64_ifort -mpi=ompi   (MPI executable / Intel OneAPI Legacy / Linux X86-64 / OpenMPI)         
          -arch=linuxa64                  (SMP executable / Armflang compiler / Linux ARM64)
          -arch=linuxa64 -mpi=ompi        (OpenMPI executable / Armflang compiler / Linux ARM64)
+         -arch=linux64_nvidia            (SMP executable / NVIDIA nvfortran compiler / Linux X86-64)
+         -arch=linux64_nvidia -mpi=ompi  (OpenMPI executable / NVIDIA nvfortran compiler / Linux X86-64)
          -arch=win64                     (SMP executable / Intel OneAPI ifx / Windows X86-64)
          -arch=win64       -mpi=impi     (Intel MPI OneAPI executable / Intel OneAPI ifx / Windows X86-64)
          -arch=win64_ifort               (SMP executable / Intel OneAPI Legacy / Windows X86-64)


### PR DESCRIPTION
Add cmake_linux64_nvidia.txt and cmake_linux64_nvidia_compilers.sh to
enable building the engine with the NVIDIA HPC SDK compilers
(nvfortran, nvc, nvc++).

Supports SMP (-arch=linux64_nvidia) and OpenMPI (-mpi=ompi) builds.
Key nvfortran flags: -mp (OpenMP), -Mnofma, -Mextend, -Mnostdinc,
-traceback, -Munroll, -Mvect=simd. The NVIDIA SDK intrinsic modules
path defaults to /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/include
and can be overridden via the NVHPC environment variable.
MUMPS/implicit solver is not yet supported for this compiler.

https://claude.ai/code/session_01JYjSfowL111KprYm5nsSzv