### PR TITLE
Add GPU broad-phase collision detection for Interface Type 7

### DIFF
--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
@@ -78,11 +78,18 @@ Copyright>        along with this program.  If not, see <https://www.gnu.org/lic
 
 /* ------------------------------------------------------------------ */
 /* Compile-time block size for the candidate kernel                    */
+/* 128 threads per block gives good occupancy on SM7+ devices          */
 /* ------------------------------------------------------------------ */
 #define BLOCK_SIZE  128
-/* Maximum candidate pairs buffered in shared memory per block before  */
-/* flushing to the global output (must be >= BLOCK_SIZE)              */
-#define BLOCK_BUF   256
+
+/*
+ * SPMD limitation
+ * Remote (SPMD) slave nodes (jj > nsn in the Fortran linked list) are NOT
+ * processed by the GPU kernel.  When nsnr > 0, the caller must supplement
+ * GPU candidate pairs with CPU-computed remote-node pairs by running the
+ * CPU inter7_candidate_pairs path after the GPU path, or by passing nsnr=0
+ * and restricting the GPU call to local nodes only.
+ */
 
 /* ------------------------------------------------------------------ */
 /* Global device state                                                 */
@@ -185,24 +192,10 @@ __global__ void kernel_fill_voxel(
         return;
     }
 
-    int ix = (int)(nbx * (xj - xminb) / (xmaxb - xminb));
-    int iy = (int)(nby * (yj - yminb) / (ymaxb - yminb));
-    int iz = (int)(nbz * (zj - zminb) / (zmaxb - zminb));
-
-    /* Fortran: MAX(1, 2+MIN(NBX, ix)) – map to [1, NBX+2] in Fortran */
-    if (ix < 0)   ix = -1; /* will become 1 after +2 clamp */
-    if (ix > nbx) ix = nbx;
-    ix = 1 + ix;   /* shift so range is [1, nbx+1]; then clamp below  */
-    /* replicate Fortran: MAX(1, 2+MIN(NBX,ix_raw)) */
-    /* We have ix_raw in [0,nbx].  2+MIN(NBX,ix_raw) in [2,nbx+2].   */
-    /* MAX(1, ...) is always 2+ for in-range nodes → range [2,nbx+2]. */
-    /* Re-compute cleanly: */
-    int ix_raw = (int)(nbx * (xj - xminb) / (xmaxb - xminb));
-    int iy_raw = (int)(nby * (yj - yminb) / (ymaxb - yminb));
-    int iz_raw = (int)(nbz * (zj - zminb) / (zmaxb - zminb));
-    ix = max(1, 2 + min(nbx, ix_raw));
-    iy = max(1, 2 + min(nby, iy_raw));
-    iz = max(1, 2 + min(nbz, iz_raw));
+    /* Mirrors Fortran: MAX(1, 2+MIN(NBX, INT(NBX*(xj-xminb)/(xmaxb-xminb)))) */
+    int ix = max(1, 2 + min(nbx, (int)(nbx * (xj - xminb) / (xmaxb - xminb))));
+    int iy = max(1, 2 + min(nby, (int)(nby * (yj - yminb) / (ymaxb - yminb))));
+    int iz = max(1, 2 + min(nbz, (int)(nbz * (zj - zminb) / (zmaxb - zminb))));
 
     /* Flat cell index (1-based in Fortran, 0-based C equivalent) */
     int cellid = (iz - 1) * (nbx + 2) * (nby + 2) + (iy - 1) * (nbx + 2) + ix - 1;
@@ -217,18 +210,17 @@ __global__ void kernel_fill_voxel(
     next_nod[i] = old_head;  /* chain the old head as our successor */
 }
 
-/* ================================================================== */
-/* Binary search helper (device)                                       */
-/* Returns true if key is found in sorted array a[lo..hi).            */
-/* ================================================================== */
-__device__ __forceinline__ bool dev_binary_search(
-    const int* __restrict__ a, int lo, int hi, int key)
+/*
+ * Linear scan over the per-segment KREMNODE list.
+ * Binary search would be faster for large lists but requires sorted input,
+ * which the Fortran code does not guarantee.  Kremnode lists are typically
+ * very short (O(10) entries = neighbouring elements), so linear scan is fine.
+ */
+__device__ __forceinline__ bool dev_kremnode_forbidden(
+    const int* __restrict__ remnod, int lo, int hi, int global_node_id)
 {
-    while (lo < hi) {
-        int mid = lo + ((hi - lo) >> 1);
-        if      (a[mid] == key) return true;
-        else if (a[mid] <  key) lo = mid + 1;
-        else                    hi = mid;
+    for (int k = lo; k < hi; k++) {
+        if (remnod[k] == global_node_id) return true;
     }
     return false;
 }
@@ -297,21 +289,29 @@ __global__ void kernel_candidate_pairs(
     __shared__ int         s_krem_lo, s_krem_hi;      /* kremnode range  */
     __shared__ int         s_valid;                   /* segment alive?  */
 
-    /* Block-level candidate buffer before global flush */
-    __shared__ int  s_buf_n[BLOCK_BUF];
-    __shared__ int  s_buf_e[BLOCK_BUF];
-    __shared__ int  s_buf_cnt;
+    /*
+     * No shared-memory output buffer.
+     * Each valid pair is written to global memory via atomicAdd on g_counter.
+     * This avoids the __syncthreads()-inside-conditional deadlock that a
+     * mid-loop flush would cause (threads exit the inner while loop at
+     * different times so a block-wide barrier inside it is illegal).
+     * atomicAdd contention is acceptable since the broad phase produces
+     * O(candidates) writes, which is small relative to the voxel traversal.
+     */
 
     if (threadIdx.x == 0) {
         s_buf_cnt = 0;
         s_valid   = (stf[ne] != (my_real_gpu)0) ? 1 : 0;
 
         if (s_valid) {
-            /* Fortran irect(k,ne+1) → C irect[ne + (k-1)*nrtm] (col-major) */
-            s_m[0] = irect[ne + 0 * nrtm];   /* M1 */
-            s_m[1] = irect[ne + 1 * nrtm];   /* M2 */
-            s_m[2] = irect[ne + 2 * nrtm];   /* M3 */
-            s_m[3] = irect[ne + 3 * nrtm];   /* M4 */
+            /*
+             * Fortran IRECT(4,NRTM) is column-major: first index (k=1..4) varies
+             * fastest in memory.  IRECT(k, ne+1) → C flat index ne*4 + (k-1).
+             */
+            s_m[0] = irect[ne * 4 + 0];   /* IRECT(1,ne+1) = M1 */
+            s_m[1] = irect[ne * 4 + 1];   /* IRECT(2,ne+1) = M2 */
+            s_m[2] = irect[ne * 4 + 2];   /* IRECT(3,ne+1) = M3 */
+            s_m[3] = irect[ne * 4 + 3];   /* IRECT(4,ne+1) = M4 */
 
             /* Node coords (Fortran: x(k,j) → C: x[3*(j-1)+(k-1)]) */
             #define XC(j,k) x[3*((j)-1)+(k)]
@@ -415,7 +415,7 @@ __global__ void kernel_candidate_pairs(
 
                         /* (b) KREMNODE forbidden pair rejection */
                         if (flagremnode == 2 && s_krem_lo < s_krem_hi) {
-                            if (dev_binary_search(remnod, s_krem_lo, s_krem_hi, nn)) {
+                            if (dev_kremnode_forbidden(remnod, s_krem_lo, s_krem_hi, nn)) {
                                 jj = next_nod[jj - 1];
                                 continue;
                             }
@@ -456,25 +456,13 @@ __global__ void kernel_candidate_pairs(
                             }
                         }
 
-                        /* Valid candidate – store in shared buffer */
-                        int slot = atomicAdd(&s_buf_cnt, 1);
-                        if (slot < BLOCK_BUF) {
-                            s_buf_n[slot] = jj;        /* local slave index (1-based) */
-                            s_buf_e[slot] = ne + 1;    /* local segment index (1-based) */
-                        }
-                        /* If buffer is full, flush now */
-                        if (slot + 1 == BLOCK_BUF) {
-                            __syncthreads();
-                            if (threadIdx.x == 0) {
-                                int base = atomicAdd(g_counter, BLOCK_BUF);
-                                int write_n = min(BLOCK_BUF, mulnsn - base);
-                                for (int k = 0; k < write_n; k++) {
-                                    cand_n[base + k] = s_buf_n[k];
-                                    cand_e[base + k] = s_buf_e[k];
-                                }
-                                s_buf_cnt = 0;
+                        /* Valid candidate – write directly to global output */
+                        {
+                            int slot = atomicAdd(g_counter, 1);
+                            if (slot < mulnsn) {
+                                cand_n[slot] = jj;      /* local slave index (1-based) */
+                                cand_e[slot] = ne + 1;  /* local segment index (1-based) */
                             }
-                            __syncthreads();
                         }
                     }
                     jj = next_nod[jj - 1];
@@ -483,19 +471,6 @@ __global__ void kernel_candidate_pairs(
         }
     }
 
-    /* Final flush of partial buffer */
-    __syncthreads();
-    if (threadIdx.x == 0 && s_buf_cnt > 0) {
-        int cnt  = s_buf_cnt;
-        int base = atomicAdd(g_counter, cnt);
-        int write_n = min(cnt, mulnsn - base);
-        if (write_n > 0) {
-            for (int k = 0; k < write_n; k++) {
-                cand_n[base + k] = s_buf_n[k];
-                cand_e[base + k] = s_buf_e[k];
-            }
-        }
-    }
 }
 
 /* ================================================================== */

--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
@@ -17,460 +17,379 @@ Copyright>        along with this program.  If not, see <https://www.gnu.org/lic
 /*
  * inter7_gpu_broadphase.cu
  *
- * GPU broad-phase collision detection for Interface Type 7.
- * See inter7_gpu_broadphase.h for the full design rationale.
+ * GPU broad-phase collision detection using PhysX 5.x PxBroadPhase (eGPU).
  *
- * Algorithm (mirrors inter7_candidate_pairs.F90 / fill_voxel.F90)
- * ================================================================
+ * Why PxBroadPhase instead of a custom CUDA voxel kernel
+ * =======================================================
+ * PhysX ships a GPU-accelerated Sort-and-Prune (SAP) broad phase
+ * (PxBroadPhaseType::eGPU) that:
+ *   - runs entirely on the GPU via CUDA
+ *   - supports incremental updates (only re-sorts objects that moved)
+ *   - handles filter groups natively (master/slave asymmetry is free)
+ *   - is heavily optimised and validated by NVIDIA
  *
- * fill_voxel GPU path (inter7_gpu_fill_voxel_)
- * --------------------------------------------
- *   Parallel over slave nodes:
- *     1. Compute flat voxel cell index from node coordinate.
- *     2. Use atomicCAS-based linked-list insertion to build the same
- *        voxel[]/next_nod[] structure as the CPU path.
- *   Output: device copies of voxel[] and next_nod[] that mirror the CPU
- *   arrays exactly, allowing hybrid CPU/GPU operation if needed.
+ * Architecture
+ * ============
  *
- * candidate_pairs GPU path (inter7_gpu_candidate_pairs_)
- * -------------------------------------------------------
- *   One CUDA block per master segment (ne = 0..nrtm-1):
- *     1. Thread 0 loads segment corners, computes inflated AABB, surface
- *        normal (sx,sy,sz), and voxel range (ix1..ix2, iy1..iy2, iz1..iz2)
- *        into shared memory.
- *     2. Threads cooperatively sweep the voxel range; each thread handles
- *        a subset of the IX dimension.
- *     3. For each node found in a voxel cell the following rejection
- *        filters are applied (early exit on first rejection):
- *          (a) Corner self-pair: node global ID == M1/M2/M3/M4 → skip.
- *          (b) KREMNODE forbidden pair: binary search in the per-segment
- *              CSR list of forbidden node IDs → skip if found.
- *          (c) Expanded AABB: node outside [xmine-aaa, xmaxe+aaa] → skip.
- *          (d) Plane-distance underestimation: same formula as CPU → skip.
- *     4. Valid pairs are accumulated in shared memory and flushed to global
- *        device output using a single atomicAdd per block flush.
+ * Step 1  build_slave_aabbs  (CUDA kernel, N threads for N slave nodes)
+ *   Each slave node i becomes a point AABB [x,x]×[y,y]×[z,z].
+ *   filterGroup = FILTER_SLAVE (0x1)
+ *   PhysX suppresses pairs when (A.group & B.group) != 0, so slave–slave
+ *   pairs are suppressed and only slave–master pairs are produced.
  *
- * PhysX integration
- * -----------------
- *   PxCudaContextManager is used for device context ownership and stream
- *   management.  This keeps CUDA contexts consistent when the calling
- *   simulation also uses PhysX (rigid-body simulation, cloth, etc.).
- *   If PhysX is not available the implementation falls back to raw CUDA.
+ * Step 2  build_segment_aabbs  (CUDA kernel, N threads for N segments)
+ *   Each master segment ne becomes an inflated AABB:
+ *     [xmine - AAA, xmaxe + AAA] in each dimension
+ *   where AAA is computed with bgapsmx (overestimation of gap_s).
+ *   filterGroup = FILTER_MASTER (0x2)
+ *
+ *   Using bgapsmx makes the AABB conservative: guaranteed to contain any
+ *   slave node that would pass the per-node AABB test (no false negatives).
+ *   False positives are removed by the post-filter (Step 4).
+ *
+ * Step 3  PxBroadPhase::update()  (GPU, inside PhysX)
+ *   Objects are submitted via PxBroadPhaseUpdateData with handle-indexed
+ *   mBounds and mGroups arrays.  PhysX Sort-and-Prune on the GPU finds all
+ *   overlapping (slave, master) AABB pairs.
+ *
+ * Step 4  postfilter_pairs  (CUDA kernel, one thread per PhysX pair)
+ *   For each pair (slave_idx, segment_idx) returned by PhysX, apply:
+ *   (a) Corner self-pair: node global ID == M1/M2/M3/M4  → reject
+ *   (b) KREMNODE forbidden pair: linear scan over per-segment list → reject
+ *   (c) Per-node expanded AABB with actual gap_s[slave_idx]         → reject
+ *   (d) Plane-distance underestimation (same formula as CPU)        → reject
+ *   Valid pairs are written to output arrays via atomicAdd.
+ *
+ * Master-surface vs slave-node asymmetry
+ * =======================================
+ * PhysX filter-group semantics: pair (A,B) suppressed iff (A.group & B.group) != 0.
+ *   FILTER_SLAVE  = 0x1:  (0x1 & 0x1)=1 → slave-slave suppressed  ✓
+ *   FILTER_MASTER = 0x2:  (0x2 & 0x2)=2 → master-master suppressed ✓
+ *   slave-master:         (0x1 & 0x2)=0 → pair generated           ✓
+ *
+ * PxBroadPhaseUpdateData API notes (PhysX 5.x)
+ * =============================================
+ * - mBounds and mGroups are handle-indexed arrays of capacity mCapacity.
+ *   If handle h is in mCreated, then mBounds[h] and mGroups[h] are read.
+ *   The arrays must remain valid until fetchResults() returns.
+ * - There is no mEnvIDs field; mCapacity is the array capacity.
+ * - We use PxBroadPhase directly (not PxAABBManager) because
+ *   PxAABBManager::update() does not accept PxBroadPhaseUpdateData.
+ * - We rebuild all objects every timestep (remove-then-add) so that
+ *   fetchResults().mCreatedPairs contains all current overlaps.
+ *   An incremental update-only approach would miss pre-existing contacts.
  */
 
 #include "inter7_gpu_broadphase.h"
 
+#include <PxPhysicsAPI.h>
 #include <cuda_runtime.h>
-#include <device_launch_parameters.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
+
+using namespace physx;
 
 /* ------------------------------------------------------------------ */
-/* Optional PhysX CUDA context manager                                 */
+/* Filter groups                                                       */
 /* ------------------------------------------------------------------ */
-#ifdef USE_PHYSX
-  #include <PxPhysicsAPI.h>
-  using namespace physx;
-  static PxFoundation*          g_foundation    = nullptr;
-  static PxCudaContextManager*  g_cudaCtxMgr    = nullptr;
-#endif
+#define FILTER_SLAVE   0x1u
+#define FILTER_MASTER  0x2u
 
 /* ------------------------------------------------------------------ */
-/* Compile-time block size for the candidate kernel                    */
-/* 128 threads per block gives good occupancy on SM7+ devices          */
-/* ------------------------------------------------------------------ */
-#define BLOCK_SIZE  128
-
-/*
- * SPMD limitation
- * Remote (SPMD) slave nodes (jj > nsn in the Fortran linked list) are NOT
- * processed by the GPU kernel.  When nsnr > 0, the caller must supplement
- * GPU candidate pairs with CPU-computed remote-node pairs by running the
- * CPU inter7_candidate_pairs path after the GPU path, or by passing nsnr=0
- * and restricting the GPU call to local nodes only.
- */
-
-/* ------------------------------------------------------------------ */
-/* Global device state                                                 */
-/* ------------------------------------------------------------------ */
-static int   g_device_id   = -1;   /* -1 = not initialised             */
-static bool  g_initialised = false;
-
-/* Device persistent buffers (reallocated as needed) */
-static int*        d_voxel     = nullptr;
-static int*        d_next_nod  = nullptr;
-static int*        d_nsv       = nullptr;
-static int*        d_irect     = nullptr;
-static int*        d_cand_n    = nullptr;
-static int*        d_cand_e    = nullptr;
-static int*        d_counter   = nullptr;   /* atomic output counter */
-static int*        d_kremnod   = nullptr;
-static int*        d_remnod    = nullptr;
-
-static my_real_gpu* d_x        = nullptr;
-static my_real_gpu* d_stf      = nullptr;
-static my_real_gpu* d_gap_s    = nullptr;
-static my_real_gpu* d_gap_m    = nullptr;
-static my_real_gpu* d_curv_max = nullptr;
-
-/* Sizes of current device allocations */
-static int g_sz_voxel   = 0;
-static int g_sz_nod     = 0;   /* nsn + nsnr */
-static int g_sz_numnod  = 0;
-static int g_sz_nrtm    = 0;
-static int g_sz_cand    = 0;
-static int g_sz_kremnod = 0;
-static int g_sz_remnod  = 0;
-
-/* ------------------------------------------------------------------ */
-/* Helpers                                                             */
+/* Error checking                                                      */
 /* ------------------------------------------------------------------ */
 #define CUDA_CHECK(call)                                                    \
   do {                                                                      \
-    cudaError_t err = (call);                                               \
-    if (err != cudaSuccess) {                                               \
-      fprintf(stderr, "[GPU BPH] CUDA error %s at %s:%d\n",               \
-              cudaGetErrorString(err), __FILE__, __LINE__);                 \
-    }                                                                       \
+    cudaError_t _e = (call);                                               \
+    if (_e != cudaSuccess)                                                  \
+      fprintf(stderr,"[GPU BPH] CUDA error %s at %s:%d\n",               \
+              cudaGetErrorString(_e),__FILE__,__LINE__);                   \
   } while(0)
 
-/* Reallocate device buffer if size has grown */
-static void ensure_device_int(int** ptr, int* cur_sz, int needed)
+/* ------------------------------------------------------------------ */
+/* Buffer helpers                                                      */
+/* ------------------------------------------------------------------ */
+/* Device buffers */
+static void ensure_device_int(int** p, int* sz, int n)
 {
-    if (needed > *cur_sz) {
-        if (*ptr) cudaFree(*ptr);
-        CUDA_CHECK(cudaMalloc(ptr, (size_t)needed * sizeof(int)));
-        *cur_sz = needed;
+    if (n > *sz) {
+        if (*p) cudaFree(*p);
+        CUDA_CHECK(cudaMalloc(p, (size_t)n * sizeof(int)));
+        *sz = n;
     }
 }
-static void ensure_device_real(my_real_gpu** ptr, int* cur_sz, int needed)
+static void ensure_device_real(my_real_gpu** p, int* sz, int n)
 {
-    if (needed > *cur_sz) {
-        if (*ptr) cudaFree(*ptr);
-        CUDA_CHECK(cudaMalloc(ptr, (size_t)needed * sizeof(my_real_gpu)));
-        *cur_sz = needed;
+    if (n > *sz) {
+        if (*p) cudaFree(*p);
+        CUDA_CHECK(cudaMalloc(p, (size_t)n * sizeof(my_real_gpu)));
+        *sz = n;
+    }
+}
+
+/* Host buffers – raw bytes, separate size per pointer */
+static void ensure_host_raw(void** p, int* sz_bytes, int nbytes)
+{
+    if (nbytes > *sz_bytes) {
+        free(*p);
+        *p = malloc((size_t)nbytes);
+        *sz_bytes = nbytes;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* AabbEntry: same memory layout as PxBounds3 (2 × PxVec3 of floats) */
+/* ------------------------------------------------------------------ */
+struct AabbEntry { float lo[3]; float hi[3]; };
+
+static void ensure_device_aabb(AabbEntry** p, int* sz, int n)
+{
+    if (n > *sz) {
+        if (*p) cudaFree(*p);
+        CUDA_CHECK(cudaMalloc(p, (size_t)n * sizeof(AabbEntry)));
+        *sz = n;
     }
 }
 
 /* ================================================================== */
-/* fill_voxel kernel                                                   */
-/* Each thread processes one slave node and inserts it into the voxel  */
-/* linked list using atomicExch-based compare-and-swap chaining.       */
+/* PhysX / CUDA global state                                          */
 /* ================================================================== */
-__global__ void kernel_fill_voxel(
-    int                    nsn,
-    const int* __restrict__ nsv,       /* slave-to-global map [nsn]          */
-    const my_real_gpu* __restrict__ x, /* node coords [3*numnod], col-major  */
+static PxDefaultAllocator       g_alloc;
+static PxDefaultErrorCallback   g_errcb;
+static PxFoundation*            g_foundation = nullptr;
+static PxCudaContextManager*    g_cudaCtxMgr = nullptr;
+static PxBroadPhase*            g_broadPhase = nullptr;  /* eGPU */
+static bool                     g_initialised = false;
+
+/* Device buffers (persistent across calls, grown on demand) */
+static my_real_gpu* d_x        = nullptr;  static int g_sz_numnod  = 0;
+static int*         d_nsv      = nullptr;  static int g_sz_nsn     = 0;
+static my_real_gpu* d_stfn     = nullptr;  /* slave stiffness, shares g_sz_nsn */
+static my_real_gpu* d_gap_s    = nullptr;  /* slave gap, shares g_sz_nsn */
+static int*         d_irect    = nullptr;  static int g_sz_nrtm    = 0;
+static my_real_gpu* d_stf      = nullptr;  /* segment stiffness, shares g_sz_nrtm */
+static my_real_gpu* d_gap_m    = nullptr;  /* segment gap, shares g_sz_nrtm */
+static my_real_gpu* d_curv_max = nullptr;  /* curvature, shares g_sz_nrtm */
+static int*         d_kremnod  = nullptr;  static int g_sz_kremnod = 0;
+static int*         d_remnod   = nullptr;  static int g_sz_remnod  = 0;
+static int*         d_cand_n   = nullptr;  static int g_sz_cand    = 0;
+static int*         d_cand_e   = nullptr;
+static int*         d_counter  = nullptr;
+
+/* GPU AABB arrays */
+static AabbEntry*   d_slave_aabbs   = nullptr;  static int g_sz_slave_aabbs   = 0;
+static AabbEntry*   d_segment_aabbs = nullptr;  static int g_sz_segment_aabbs = 0;
+static int*         d_slave_active  = nullptr;  static int g_sz_slave_act     = 0;
+static int*         d_seg_active    = nullptr;  static int g_sz_seg_act       = 0;
+
+/* GPU pair arrays (post PhysX) */
+static int*         d_pair_slave    = nullptr;  static int g_sz_pairs_d       = 0;
+static int*         d_pair_seg      = nullptr;
+
+/* ---- Host arrays ---- */
+
+/* AABB and active masks downloaded from GPU */
+static AabbEntry*   h_slave_aabbs   = nullptr;  static int h_sz_sa_bytes    = 0;
+static AabbEntry*   h_segment_aabbs = nullptr;  static int h_sz_seg_bytes   = 0;
+static int*         h_slave_active  = nullptr;  static int h_sz_sact_bytes  = 0;
+static int*         h_seg_active    = nullptr;  static int h_sz_seact_bytes = 0;
+
+/*
+ * PhysX update arrays – HANDLE-INDEXED.
+ * h_bounds[handle] and h_groups[handle] must be filled for every handle
+ * in h_created[].  Capacity = total_objs = nsn + nrtm.
+ * h_bounds has the same memory layout as PxBounds3 (cast is safe).
+ */
+static AabbEntry*   h_bounds  = nullptr;  static int h_sz_bnd_bytes = 0;
+static PxU32*       h_groups  = nullptr;  static int h_sz_grp_bytes = 0;
+static PxU32*       h_created = nullptr;  static int h_sz_cr_bytes  = 0;
+static PxU32*       h_removed = nullptr;  static int h_sz_rm_bytes  = 0;
+
+/* Pair host buffers */
+static int*         h_pair_slave = nullptr;  static int h_sz_ps_bytes = 0;
+static int*         h_pair_seg   = nullptr;  static int h_sz_pe_bytes = 0;
+
+/* ================================================================== */
+/* Step 1: build slave-node AABBs                                     */
+/* Point AABB at the node position; inactive if stfn==0.             */
+/* ================================================================== */
+__global__ void kernel_build_slave_aabbs(
+    int                        nsn,
+    const int* __restrict__    nsv,
+    const my_real_gpu* __restrict__ x,
     const my_real_gpu* __restrict__ stfn,
-    my_real_gpu xmin, my_real_gpu ymin, my_real_gpu zmin,
-    my_real_gpu xmax, my_real_gpu ymax, my_real_gpu zmax,
-    my_real_gpu xminb, my_real_gpu yminb, my_real_gpu zminb,
-    my_real_gpu xmaxb, my_real_gpu ymaxb, my_real_gpu zmaxb,
-    int nbx, int nby, int nbz,
-    int* __restrict__ voxel,           /* voxel head [(nbx+2)*(nby+2)*(nbz+2)] */
-    int* __restrict__ next_nod         /* next-node chain [nsn]                */
+    AabbEntry* __restrict__    aabbs,
+    int* __restrict__          active
 )
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= nsn) return;
-
-    /* Fortran 1-based index i+1 → local index i (0-based in C) */
-    if (stfn[i] == (my_real_gpu)0) {
-        next_nod[i] = 0;
-        return;
-    }
-
-    /* Fortran: j = NSV(i+1),  x(1,j) stored at x[3*(j-1)+0] */
-    int j = nsv[i] - 1;   /* 0-based global node index */
-    my_real_gpu xj = x[3*j + 0];
-    my_real_gpu yj = x[3*j + 1];
-    my_real_gpu zj = x[3*j + 2];
-
-    if (xj < xmin || xj > xmax || yj < ymin || yj > ymax || zj < zmin || zj > zmax) {
-        next_nod[i] = 0;
-        return;
-    }
-
-    /* Mirrors Fortran: MAX(1, 2+MIN(NBX, INT(NBX*(xj-xminb)/(xmaxb-xminb)))) */
-    int ix = max(1, 2 + min(nbx, (int)(nbx * (xj - xminb) / (xmaxb - xminb))));
-    int iy = max(1, 2 + min(nby, (int)(nby * (yj - yminb) / (ymaxb - yminb))));
-    int iz = max(1, 2 + min(nbz, (int)(nbz * (zj - zminb) / (zmaxb - zminb))));
-
-    /* Flat cell index (1-based in Fortran, 0-based C equivalent) */
-    int cellid = (iz - 1) * (nbx + 2) * (nby + 2) + (iy - 1) * (nbx + 2) + ix - 1;
-
-    /*
-     * Atomic linked-list insertion.
-     * voxel[cellid] holds the index (1-based, Fortran convention) of the
-     * first node in the cell, or 0 if empty.
-     * We insert node i+1 (Fortran 1-based) at the head atomically.
-     */
-    int old_head = atomicExch(&voxel[cellid], i + 1);  /* +1: Fortran 1-based */
-    next_nod[i] = old_head;  /* chain the old head as our successor */
+    if (stfn[i] == (my_real_gpu)0) { active[i] = 0; return; }
+    active[i] = 1;
+    int j = nsv[i] - 1;
+    float xj = (float)x[3*j + 0];
+    float yj = (float)x[3*j + 1];
+    float zj = (float)x[3*j + 2];
+    aabbs[i].lo[0] = xj; aabbs[i].lo[1] = yj; aabbs[i].lo[2] = zj;
+    aabbs[i].hi[0] = xj; aabbs[i].hi[1] = yj; aabbs[i].hi[2] = zj;
 }
 
-/*
- * Linear scan over the per-segment KREMNODE list.
- * Binary search would be faster for large lists but requires sorted input,
- * which the Fortran code does not guarantee.  Kremnode lists are typically
- * very short (O(10) entries = neighbouring elements), so linear scan is fine.
- */
-__device__ __forceinline__ bool dev_kremnode_forbidden(
-    const int* __restrict__ remnod, int lo, int hi, int global_node_id)
+/* ================================================================== */
+/* Step 2: build master-segment AABBs                                 */
+/* Inflated by AAA computed with bgapsmx so the box is conservative. */
+/* ================================================================== */
+__global__ void kernel_build_segment_aabbs(
+    int                         nrtm,
+    const int* __restrict__     irect,
+    const my_real_gpu* __restrict__ x,
+    const my_real_gpu* __restrict__ stf,
+    const my_real_gpu* __restrict__ gap_m,
+    const my_real_gpu* __restrict__ curv_max,
+    my_real_gpu marge, my_real_gpu tzinf,
+    my_real_gpu gapmin, my_real_gpu gapmax,
+    my_real_gpu bgapsmx, my_real_gpu dgapload, my_real_gpu drad,
+    int         igap,
+    AabbEntry* __restrict__     aabbs,
+    int* __restrict__           active
+)
 {
-    for (int k = lo; k < hi; k++) {
-        if (remnod[k] == global_node_id) return true;
+    int ne = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ne >= nrtm) return;
+    if (stf[ne] == (my_real_gpu)0) { active[ne] = 0; return; }
+    active[ne] = 1;
+
+    /* IRECT(4,NRTM) column-major: IRECT(k,ne+1) = irect[ne*4 + k] (0-based k) */
+    int m0 = irect[ne*4 + 0] - 1;
+    int m1 = irect[ne*4 + 1] - 1;
+    int m2 = irect[ne*4 + 2] - 1;
+    int m3 = irect[ne*4 + 3] - 1;
+
+    float xx0=(float)x[3*m0],xx1=(float)x[3*m1],xx2=(float)x[3*m2],xx3=(float)x[3*m3];
+    float yy0=(float)x[3*m0+1],yy1=(float)x[3*m1+1],yy2=(float)x[3*m2+1],yy3=(float)x[3*m3+1];
+    float zz0=(float)x[3*m0+2],zz1=(float)x[3*m1+2],zz2=(float)x[3*m2+2],zz3=(float)x[3*m3+2];
+
+    float xmine = fminf(fminf(xx0,xx1),fminf(xx2,xx3));
+    float xmaxe = fmaxf(fmaxf(xx0,xx1),fmaxf(xx2,xx3));
+    float ymine = fminf(fminf(yy0,yy1),fminf(yy2,yy3));
+    float ymaxe = fmaxf(fmaxf(yy0,yy1),fmaxf(yy2,yy3));
+    float zmine = fminf(fminf(zz0,zz1),fminf(zz2,zz3));
+    float zmaxe = fmaxf(fmaxf(zz0,zz1),fmaxf(zz2,zz3));
+
+    float aaa;
+    if (igap == 0) {
+        aaa = (float)(tzinf + curv_max[ne]);
+    } else {
+        float g = fminf((float)gapmax, fmaxf((float)gapmin,
+                        (float)(bgapsmx + gap_m[ne]))) + (float)dgapload;
+        aaa = (float)(marge + curv_max[ne]) + fmaxf(g, (float)drad);
     }
-    return false;
+
+    aabbs[ne].lo[0] = xmine - aaa;
+    aabbs[ne].lo[1] = ymine - aaa;
+    aabbs[ne].lo[2] = zmine - aaa;
+    aabbs[ne].hi[0] = xmaxe + aaa;
+    aabbs[ne].hi[1] = ymaxe + aaa;
+    aabbs[ne].hi[2] = zmaxe + aaa;
 }
 
 /* ================================================================== */
-/* Candidate pairs kernel                                              */
-/* One block per master segment.  Threads cooperate over the voxel     */
-/* range of the segment's inflated AABB.                               */
+/* Step 4: post-filter PhysX pairs                                    */
 /* ================================================================== */
-__global__ void kernel_candidate_pairs(
-    /* geometry */
-    int                     nrtm,
-    int                     nsn,
-    const int* __restrict__ irect,         /* [4 * nrtm], col-major: irect[ne + k*nrtm] */
-    const my_real_gpu* __restrict__ x,     /* [3 * numnod], col-major */
-    const int* __restrict__ nsv,           /* [nsn]                   */
-    const int* __restrict__ voxel,         /* [(nbx+2)*(nby+2)*(nbz+2)] */
-    const int* __restrict__ next_nod,      /* [nsn+nsnr]              */
-    /* bounding box */
-    my_real_gpu xminb, my_real_gpu yminb, my_real_gpu zminb,
-    my_real_gpu xmaxb, my_real_gpu ymaxb, my_real_gpu zmaxb,
-    int nbx, int nby, int nbz,
-    /* gap / contact parameters */
-    int igap,
-    my_real_gpu marge,
-    my_real_gpu tzinf,
-    my_real_gpu gap,
-    my_real_gpu gapmin, my_real_gpu gapmax, my_real_gpu bgapsmx,
-    my_real_gpu drad,   my_real_gpu dgapload,
+__global__ void kernel_postfilter_pairs(
+    int                          npairs,
+    const int* __restrict__      pair_slave,
+    const int* __restrict__      pair_seg,
+    int                          nrtm,
+    const int* __restrict__      irect,
+    const my_real_gpu* __restrict__ x,
+    const int* __restrict__      nsv,
+    int                          igap,
+    my_real_gpu                  marge,
+    my_real_gpu                  gapmin, my_real_gpu gapmax,
+    my_real_gpu                  dgapload, my_real_gpu drad,
     const my_real_gpu* __restrict__ gap_s,
     const my_real_gpu* __restrict__ gap_m,
     const my_real_gpu* __restrict__ curv_max,
-    const my_real_gpu* __restrict__ stf,
-    /* kremnode rejection (CSR format) */
-    int flagremnode,
-    const int* __restrict__ kremnod,   /* [s_kremnod] – see below */
-    const int* __restrict__ remnod,    /* [s_remnod]              */
-    /*
-     * KREMNODE CSR layout (0-based C, Fortran 1-based in the original):
-     *   for segment ne (0-based):
-     *     local forbidden: remnod[ kremnod[2*ne] .. kremnod[2*ne+1]-1 ]
-     *   (sorted ascending per segment)
-     */
-    /* output */
-    int*  cand_n,      /* [mulnsn] */
-    int*  cand_e,      /* [mulnsn] */
-    int*  g_counter,   /* global atomic counter */
-    int   mulnsn       /* max candidates        */
+    int                          flagremnode,
+    const int* __restrict__      kremnod,  /* CSR ptr [2*nrtm]: [start,end) */
+    const int* __restrict__      remnod,
+    int*                         cand_n,
+    int*                         cand_e,
+    int*                         g_counter,
+    int                          mulnsn
 )
 {
-    /* Each block handles one segment */
-    int ne = blockIdx.x;
-    if (ne >= nrtm) return;
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid >= npairs) return;
 
-    /* ---------------------------------------------------------------- */
-    /* Shared memory                                                     */
-    /* ---------------------------------------------------------------- */
-    __shared__ my_real_gpu s_xx[4], s_yy[4], s_zz[4]; /* corner coords  */
-    __shared__ my_real_gpu s_sx, s_sy, s_sz, s_s2;    /* surface normal */
-    __shared__ my_real_gpu s_xmine, s_ymine, s_zmine;
-    __shared__ my_real_gpu s_xmaxe, s_ymaxe, s_zmaxe;
-    __shared__ my_real_gpu s_aaa;                      /* influence zone  */
-    __shared__ int         s_m[4];                    /* corner node IDs */
-    __shared__ int         s_ix1, s_iy1, s_iz1;
-    __shared__ int         s_ix2, s_iy2, s_iz2;
-    __shared__ int         s_krem_lo, s_krem_hi;      /* kremnode range  */
-    __shared__ int         s_valid;                   /* segment alive?  */
+    int slave_idx = pair_slave[tid];
+    int ne        = pair_seg[tid];
 
-    /*
-     * No shared-memory output buffer.
-     * Each valid pair is written to global memory via atomicAdd on g_counter.
-     * This avoids the __syncthreads()-inside-conditional deadlock that a
-     * mid-loop flush would cause (threads exit the inner while loop at
-     * different times so a block-wide barrier inside it is illegal).
-     * atomicAdd contention is acceptable since the broad phase produces
-     * O(candidates) writes, which is small relative to the voxel traversal.
-     */
+    int nn = nsv[slave_idx];   /* global node ID (1-based Fortran) */
 
-    if (threadIdx.x == 0) {
-        s_buf_cnt = 0;
-        s_valid   = (stf[ne] != (my_real_gpu)0) ? 1 : 0;
+    /* (a) Corner self-pair */
+    int m0 = irect[ne*4 + 0];
+    int m1 = irect[ne*4 + 1];
+    int m2 = irect[ne*4 + 2];
+    int m3 = irect[ne*4 + 3];
+    if (nn == m0 || nn == m1 || nn == m2 || nn == m3) return;
 
-        if (s_valid) {
-            /*
-             * Fortran IRECT(4,NRTM) is column-major: first index (k=1..4) varies
-             * fastest in memory.  IRECT(k, ne+1) → C flat index ne*4 + (k-1).
-             */
-            s_m[0] = irect[ne * 4 + 0];   /* IRECT(1,ne+1) = M1 */
-            s_m[1] = irect[ne * 4 + 1];   /* IRECT(2,ne+1) = M2 */
-            s_m[2] = irect[ne * 4 + 2];   /* IRECT(3,ne+1) = M3 */
-            s_m[3] = irect[ne * 4 + 3];   /* IRECT(4,ne+1) = M4 */
-
-            /* Node coords (Fortran: x(k,j) → C: x[3*(j-1)+(k-1)]) */
-            #define XC(j,k) x[3*((j)-1)+(k)]
-            s_xx[0] = XC(s_m[0], 0); s_yy[0] = XC(s_m[0], 1); s_zz[0] = XC(s_m[0], 2);
-            s_xx[1] = XC(s_m[1], 0); s_yy[1] = XC(s_m[1], 1); s_zz[1] = XC(s_m[1], 2);
-            s_xx[2] = XC(s_m[2], 0); s_yy[2] = XC(s_m[2], 1); s_zz[2] = XC(s_m[2], 2);
-            s_xx[3] = XC(s_m[3], 0); s_yy[3] = XC(s_m[3], 1); s_zz[3] = XC(s_m[3], 2);
-            #undef XC
-
-            s_xmaxe = max(max(s_xx[0], s_xx[1]), max(s_xx[2], s_xx[3]));
-            s_xmine = min(min(s_xx[0], s_xx[1]), min(s_xx[2], s_xx[3]));
-            s_ymaxe = max(max(s_yy[0], s_yy[1]), max(s_yy[2], s_yy[3]));
-            s_ymine = min(min(s_yy[0], s_yy[1]), min(s_yy[2], s_yy[3]));
-            s_zmaxe = max(max(s_zz[0], s_zz[1]), max(s_zz[2], s_zz[3]));
-            s_zmine = min(min(s_zz[0], s_zz[1]), min(s_zz[2], s_zz[3]));
-
-            /* Surface normal (cross product of diagonals, same as CPU) */
-            s_sx = (s_yy[2]-s_yy[0])*(s_zz[3]-s_zz[1]) - (s_zz[2]-s_zz[0])*(s_yy[3]-s_yy[1]);
-            s_sy = (s_zz[2]-s_zz[0])*(s_xx[3]-s_xx[1]) - (s_xx[2]-s_xx[0])*(s_zz[3]-s_zz[1]);
-            s_sz = (s_xx[2]-s_xx[0])*(s_yy[3]-s_yy[1]) - (s_yy[2]-s_yy[0])*(s_xx[3]-s_xx[1]);
-            s_s2 = s_sx*s_sx + s_sy*s_sy + s_sz*s_sz;
-
-            /* Influence zone radius */
-            if (igap == 0) {
-                s_aaa = tzinf + curv_max[ne];
-            } else {
-                my_real_gpu g = min(gapmax, max(gapmin, bgapsmx + gap_m[ne])) + dgapload;
-                s_aaa = marge + curv_max[ne] + max(g, drad);
-            }
-
-            /* Voxel range for inflated AABB */
-            int ix1r, ix2r, iy1r, iy2r, iz1r, iz2r;
-            if (nbx > 1) {
-                my_real_gpu inv_dx = nbx / (xmaxb - xminb);
-                ix1r = (int)((s_xmine - s_aaa - xminb) * inv_dx);
-                ix2r = (int)((s_xmaxe + s_aaa - xminb) * inv_dx);
-            } else { ix1r = -2; ix2r = 1; }
-            if (nby > 1) {
-                my_real_gpu inv_dy = nby / (ymaxb - yminb);
-                iy1r = (int)((s_ymine - s_aaa - yminb) * inv_dy);
-                iy2r = (int)((s_ymaxe + s_aaa - yminb) * inv_dy);
-            } else { iy1r = -2; iy2r = 1; }
-            if (nbz > 1) {
-                my_real_gpu inv_dz = nbz / (zmaxb - zminb);
-                iz1r = (int)((s_zmine - s_aaa - zminb) * inv_dz);
-                iz2r = (int)((s_zmaxe + s_aaa - zminb) * inv_dz);
-            } else { iz1r = -2; iz2r = 1; }
-
-            s_ix1 = max(1, 2 + min(nbx, ix1r));
-            s_iy1 = max(1, 2 + min(nby, iy1r));
-            s_iz1 = max(1, 2 + min(nbz, iz1r));
-            s_ix2 = max(1, 2 + min(nbx, ix2r));
-            s_iy2 = max(1, 2 + min(nby, iy2r));
-            s_iz2 = max(1, 2 + min(nbz, iz2r));
-
-            /* KREMNODE range for this segment (CSR 0-based) */
-            if (flagremnode == 2) {
-                s_krem_lo = kremnod[2 * ne];
-                s_krem_hi = kremnod[2 * ne + 1];
-            } else {
-                s_krem_lo = 0;
-                s_krem_hi = 0;
-            }
-        }
-    }
-    __syncthreads();
-
-    if (!s_valid) return;
-
-    /* ---------------------------------------------------------------- */
-    /* Sweep voxel range: distribute IX over threads in the block        */
-    /* ---------------------------------------------------------------- */
-    int ix_range = s_ix2 - s_ix1 + 1;
-    int nbx2     = nbx + 2;
-    int nbxnby   = nbx2 * (nby + 2);
-
-    for (int iz = s_iz1; iz <= s_iz2; iz++) {
-        for (int iy = s_iy1; iy <= s_iy2; iy++) {
-            /* Base cell index for (iz, iy, *) */
-            int cell_base = (iz - 1) * nbxnby + (iy - 1) * nbx2;
-
-            for (int ix_off = threadIdx.x; ix_off < ix_range; ix_off += blockDim.x) {
-                int ix = s_ix1 + ix_off;
-                int cellid = cell_base + ix - 1;   /* 0-based flat index */
-
-                /* Walk the linked list for this cell */
-                int jj = voxel[cellid];
-                while (jj > 0) {
-                    /* Only local slave nodes (jj <= nsn).
-                     * Remote SPMD nodes (jj > nsn) are handled by the CPU
-                     * path (SPMD exchange precedes this call) – skip here. */
-                    if (jj <= nsn) {
-                        int nn = nsv[jj - 1];  /* global node ID (1-based) */
-
-                        /* (a) Corner self-pair rejection */
-                        if (nn == s_m[0] || nn == s_m[1] ||
-                            nn == s_m[2] || nn == s_m[3]) {
-                            jj = next_nod[jj - 1];
-                            continue;
-                        }
-
-                        /* (b) KREMNODE forbidden pair rejection */
-                        if (flagremnode == 2 && s_krem_lo < s_krem_hi) {
-                            if (dev_kremnode_forbidden(remnod, s_krem_lo, s_krem_hi, nn)) {
-                                jj = next_nod[jj - 1];
-                                continue;
-                            }
-                        }
-
-                        /* Node position */
-                        my_real_gpu xs = x[3*(nn-1) + 0];
-                        my_real_gpu ys = x[3*(nn-1) + 1];
-                        my_real_gpu zs = x[3*(nn-1) + 2];
-
-                        /* Per-node AAA when igap != 0 */
-                        my_real_gpu aaa = s_aaa;
-                        if (igap != 0) {
-                            my_real_gpu g = min(gapmax, max(gapmin,
-                                gap_s[jj-1] + gap_m[ne])) + dgapload;
-                            aaa = marge + curv_max[ne] + max(g, drad);
-                        }
-
-                        /* (c) Expanded AABB rejection */
-                        if (xs <= s_xmine - aaa || xs >= s_xmaxe + aaa ||
-                            ys <= s_ymine - aaa || ys >= s_ymaxe + aaa ||
-                            zs <= s_zmine - aaa || zs >= s_zmaxe + aaa) {
-                            jj = next_nod[jj - 1];
-                            continue;
-                        }
-
-                        /* (d) Plane-distance underestimation (same as CPU) */
-                        my_real_gpu d1x = xs - s_xx[0], d1y = ys - s_yy[0], d1z = zs - s_zz[0];
-                        my_real_gpu d2x = xs - s_xx[1], d2y = ys - s_yy[1], d2z = zs - s_zz[1];
-                        my_real_gpu dd1 = d1x*s_sx + d1y*s_sy + d1z*s_sz;
-                        my_real_gpu dd2 = d2x*s_sx + d2y*s_sy + d2z*s_sz;
-                        if (dd1 * dd2 > (my_real_gpu)0) {
-                            my_real_gpu d2  = min(dd1*dd1, dd2*dd2);
-                            my_real_gpu a2  = aaa*aaa*s_s2;
-                            if (d2 > a2) {
-                                jj = next_nod[jj - 1];
-                                continue;
-                            }
-                        }
-
-                        /* Valid candidate – write directly to global output */
-                        {
-                            int slot = atomicAdd(g_counter, 1);
-                            if (slot < mulnsn) {
-                                cand_n[slot] = jj;      /* local slave index (1-based) */
-                                cand_e[slot] = ne + 1;  /* local segment index (1-based) */
-                            }
-                        }
-                    }
-                    jj = next_nod[jj - 1];
-                }
-            }
+    /* (b) KREMNODE linear scan (no sort requirement) */
+    if (flagremnode == 2) {
+        int lo = kremnod[2 * ne];
+        int hi = kremnod[2 * ne + 1];
+        for (int k = lo; k < hi; k++) {
+            if (remnod[k] == nn) return;
         }
     }
 
+    int jg = nn - 1;
+    my_real_gpu xs = x[3*jg + 0];
+    my_real_gpu ys = x[3*jg + 1];
+    my_real_gpu zs = x[3*jg + 2];
+
+    int jm0 = m0-1, jm1 = m1-1, jm2 = m2-1, jm3 = m3-1;
+    my_real_gpu xx0=x[3*jm0],xx1=x[3*jm1],xx2=x[3*jm2],xx3=x[3*jm3];
+    my_real_gpu yy0=x[3*jm0+1],yy1=x[3*jm1+1],yy2=x[3*jm2+1],yy3=x[3*jm3+1];
+    my_real_gpu zz0=x[3*jm0+2],zz1=x[3*jm1+2],zz2=x[3*jm2+2],zz3=x[3*jm3+2];
+
+    my_real_gpu xmine = min(min(xx0,xx1),min(xx2,xx3));
+    my_real_gpu xmaxe = max(max(xx0,xx1),max(xx2,xx3));
+    my_real_gpu ymine = min(min(yy0,yy1),min(yy2,yy3));
+    my_real_gpu ymaxe = max(max(yy0,yy1),max(yy2,yy3));
+    my_real_gpu zmine = min(min(zz0,zz1),min(zz2,zz3));
+    my_real_gpu zmaxe = max(max(zz0,zz1),max(zz2,zz3));
+
+    /* (c) Per-node AABB with actual gap_s (igap!=0 only) */
+    my_real_gpu aaa = (my_real_gpu)0;
+    if (igap != 0) {
+        my_real_gpu g = min(gapmax, max(gapmin, gap_s[slave_idx] + gap_m[ne])) + dgapload;
+        aaa = marge + curv_max[ne] + max(g, drad);
+        if (xs <= xmine - aaa || xs >= xmaxe + aaa ||
+            ys <= ymine - aaa || ys >= ymaxe + aaa ||
+            zs <= zmine - aaa || zs >= zmaxe + aaa) return;
+    }
+
+    /* (d) Plane-distance underestimation */
+    my_real_gpu sx = (yy2-yy0)*(zz3-zz1) - (zz2-zz0)*(yy3-yy1);
+    my_real_gpu sy = (zz2-zz0)*(xx3-xx1) - (xx2-xx0)*(zz3-zz1);
+    my_real_gpu sz = (xx2-xx0)*(yy3-yy1) - (yy2-yy0)*(xx3-xx1);
+    my_real_gpu s2 = sx*sx + sy*sy + sz*sz;
+    my_real_gpu d1x=xs-xx0, d1y=ys-yy0, d1z=zs-zz0;
+    my_real_gpu d2x=xs-xx1, d2y=ys-yy1, d2z=zs-zz1;
+    my_real_gpu dd1=d1x*sx+d1y*sy+d1z*sz;
+    my_real_gpu dd2=d2x*sx+d2y*sy+d2z*sz;
+    if (dd1*dd2 > (my_real_gpu)0) {
+        my_real_gpu d2 = min(dd1*dd1, dd2*dd2);
+        my_real_gpu a2 = aaa*aaa*s2;
+        if (d2 > a2) return;
+    }
+
+    int slot = atomicAdd(g_counter, 1);
+    if (slot < mulnsn) {
+        cand_n[slot] = slave_idx + 1;
+        cand_e[slot] = ne + 1;
+    }
 }
 
 /* ================================================================== */
@@ -481,41 +400,34 @@ int inter7_gpu_broadphase_init_(void)
 {
     if (g_initialised) return 0;
 
-    int device_count = 0;
-    cudaError_t err = cudaGetDeviceCount(&device_count);
-    if (err != cudaSuccess || device_count == 0) {
-        fprintf(stderr, "[GPU BPH] No CUDA-capable device found.\n");
-        return 1;
-    }
-
-    /* Pick device 0 (or the one set by CUDA_VISIBLE_DEVICES) */
-    g_device_id = 0;
-    CUDA_CHECK(cudaSetDevice(g_device_id));
-
-#ifdef USE_PHYSX
-    /* Initialise PhysX Foundation and CUDA context manager */
-    g_foundation = PxCreateFoundation(PX_PHYSICS_VERSION,
-                                      gDefaultAllocatorCallback,
-                                      gDefaultErrorCallback);
+    g_foundation = PxCreateFoundation(PX_PHYSICS_VERSION, g_alloc, g_errcb);
     if (!g_foundation) {
-        fprintf(stderr, "[GPU BPH] PhysX Foundation init failed.\n");
+        fprintf(stderr, "[GPU BPH] PxCreateFoundation failed.\n");
         return 1;
     }
+
     PxCudaContextManagerDesc cudaCtxDesc;
     g_cudaCtxMgr = PxCreateCudaContextManager(*g_foundation, cudaCtxDesc,
                                                PxGetProfilerCallback());
     if (!g_cudaCtxMgr || !g_cudaCtxMgr->contextIsValid()) {
-        fprintf(stderr, "[GPU BPH] PhysX CUDA context init failed.\n");
+        fprintf(stderr, "[GPU BPH] CUDA context init failed.\n");
+        g_foundation->release(); g_foundation = nullptr;
         return 1;
     }
-    fprintf(stderr, "[GPU BPH] PhysX CUDA context manager ready.\n");
-#endif
 
-    /* Allocate the atomic output counter */
+    PxBroadPhaseDesc bpDesc(PxBroadPhaseType::eGPU);
+    bpDesc.mContextManager = g_cudaCtxMgr;
+    g_broadPhase = PxCreateBroadPhase(bpDesc);
+    if (!g_broadPhase) {
+        fprintf(stderr, "[GPU BPH] PxCreateBroadPhase(eGPU) failed.\n");
+        g_cudaCtxMgr->release(); g_cudaCtxMgr = nullptr;
+        g_foundation->release(); g_foundation = nullptr;
+        return 1;
+    }
+
     CUDA_CHECK(cudaMalloc(&d_counter, sizeof(int)));
-    CUDA_CHECK(cudaMemset(d_counter, 0, sizeof(int)));
-
     g_initialised = true;
+    fprintf(stderr, "[GPU BPH] PhysX eGPU broad phase ready.\n");
     return 0;
 }
 
@@ -523,114 +435,60 @@ void inter7_gpu_broadphase_destroy_(void)
 {
     if (!g_initialised) return;
 
-    if (d_voxel)    { cudaFree(d_voxel);    d_voxel    = nullptr; }
-    if (d_next_nod) { cudaFree(d_next_nod); d_next_nod = nullptr; }
-    if (d_nsv)      { cudaFree(d_nsv);      d_nsv      = nullptr; }
-    if (d_irect)    { cudaFree(d_irect);    d_irect    = nullptr; }
-    if (d_cand_n)   { cudaFree(d_cand_n);   d_cand_n   = nullptr; }
-    if (d_cand_e)   { cudaFree(d_cand_e);   d_cand_e   = nullptr; }
-    if (d_counter)  { cudaFree(d_counter);  d_counter  = nullptr; }
-    if (d_kremnod)  { cudaFree(d_kremnod);  d_kremnod  = nullptr; }
-    if (d_remnod)   { cudaFree(d_remnod);   d_remnod   = nullptr; }
-    if (d_x)        { cudaFree(d_x);        d_x        = nullptr; }
-    if (d_stf)      { cudaFree(d_stf);      d_stf      = nullptr; }
-    if (d_gap_s)    { cudaFree(d_gap_s);    d_gap_s    = nullptr; }
-    if (d_gap_m)    { cudaFree(d_gap_m);    d_gap_m    = nullptr; }
-    if (d_curv_max) { cudaFree(d_curv_max); d_curv_max = nullptr; }
-
-    g_sz_voxel = g_sz_nod = g_sz_numnod = g_sz_nrtm = 0;
-    g_sz_cand  = g_sz_kremnod = g_sz_remnod = 0;
-
-#ifdef USE_PHYSX
+    if (g_broadPhase) { g_broadPhase->release(); g_broadPhase = nullptr; }
     if (g_cudaCtxMgr) { g_cudaCtxMgr->release(); g_cudaCtxMgr = nullptr; }
-    if (g_foundation)  { g_foundation->release();  g_foundation  = nullptr; }
-#endif
+    if (g_foundation)  { g_foundation->release(); g_foundation  = nullptr; }
+
+    auto cfree = [](void* p){ if(p) cudaFree(p); };
+    cfree(d_x);      cfree(d_nsv);      cfree(d_stfn);     cfree(d_gap_s);
+    cfree(d_irect);  cfree(d_stf);      cfree(d_gap_m);    cfree(d_curv_max);
+    cfree(d_kremnod);cfree(d_remnod);   cfree(d_cand_n);   cfree(d_cand_e);
+    cfree(d_counter);
+    cfree(d_slave_aabbs); cfree(d_segment_aabbs);
+    cfree(d_slave_active); cfree(d_seg_active);
+    cfree(d_pair_slave);  cfree(d_pair_seg);
+
+    free(h_slave_aabbs);   free(h_segment_aabbs);
+    free(h_slave_active);  free(h_seg_active);
+    free(h_bounds);        free(h_groups);
+    free(h_created);       free(h_removed);
+    free(h_pair_slave);    free(h_pair_seg);
 
     g_initialised = false;
 }
 
-int inter7_gpu_available_(void)
-{
-    return g_initialised ? 1 : 0;
-}
+int inter7_gpu_available_(void) { return g_initialised ? 1 : 0; }
 
 /* ------------------------------------------------------------------ */
+/* fill_voxel stub: not used in the PhysX path                        */
+/* ------------------------------------------------------------------ */
 void inter7_gpu_fill_voxel_(
-    const int*       nsn,
-    const int*       nsnr,
-    const int*       nbx,
-    const int*       nby,
-    const int*       nbz,
-    const int*       nrtm,
-    const int*       numnod,
-    const int*       nsv,
-    const my_real_gpu* x,
-    const my_real_gpu* stfn,
-    const my_real_gpu* box_limit  /* same layout as BMINMA in fill_voxel.F90 */
-)
+    const int* nsn, const int* nsnr,
+    const int* nbx, const int* nby, const int* nbz,
+    const int* nrtm, const int* numnod,
+    const int* nsv, const my_real_gpu* x, const my_real_gpu* stfn,
+    const my_real_gpu* box_limit)
 {
-    if (!g_initialised) return;
-    if (*nrtm == 0 || *nsn == 0) return;
-
-    int h_nbx = *nbx, h_nby = *nby, h_nbz = *nbz;
-    int h_nsn = *nsn, h_nsnr = *nsnr, h_numnod = *numnod;
-    int voxel_sz = (h_nbx + 2) * (h_nby + 2) * (h_nbz + 2);
-    int nod_sz   = h_nsn + h_nsnr;
-
-    /* Reallocate device buffers as needed */
-    ensure_device_int(&d_voxel,     &g_sz_voxel,  voxel_sz);
-    ensure_device_int(&d_next_nod,  &g_sz_nod,    nod_sz);
-    ensure_device_int(&d_nsv,       &g_sz_nod,    h_nsn);      /* may already be large enough */
-    ensure_device_real(&d_x,        &g_sz_numnod, 3 * h_numnod);
-
-    /* BMINMA layout: (1)=xmax,(2)=ymax,(3)=zmax,(4)=xmin,...
-     * xmin = box_limit[3], xmax = box_limit[0] (0-based C) */
-    my_real_gpu h_xmax  = box_limit[0], h_ymax  = box_limit[1], h_zmax  = box_limit[2];
-    my_real_gpu h_xmin  = box_limit[3], h_ymin  = box_limit[4], h_zmin  = box_limit[5];
-    my_real_gpu h_xmaxb = box_limit[6], h_ymaxb = box_limit[7], h_zmaxb = box_limit[8];
-    my_real_gpu h_xminb = box_limit[9], h_yminb = box_limit[10],h_zminb = box_limit[11];
-
-    /* Upload */
-    CUDA_CHECK(cudaMemset(d_voxel,   0, (size_t)voxel_sz * sizeof(int)));
-    CUDA_CHECK(cudaMemset(d_next_nod,0, (size_t)nod_sz   * sizeof(int)));
-    CUDA_CHECK(cudaMemcpy(d_nsv, nsv,  (size_t)h_nsn * sizeof(int),       cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(d_x,   x,    (size_t)3*h_numnod*sizeof(my_real_gpu), cudaMemcpyHostToDevice));
-
-    /* Also upload stfn (reuse d_gap_s buffer for this call) */
-    ensure_device_real(&d_gap_s, &g_sz_nrtm, h_nsn);
-    CUDA_CHECK(cudaMemcpy(d_gap_s, stfn, (size_t)h_nsn * sizeof(my_real_gpu), cudaMemcpyHostToDevice));
-
-    /* Launch kernel */
-    int threads = 256;
-    int blocks  = (h_nsn + threads - 1) / threads;
-    kernel_fill_voxel<<<blocks, threads>>>(
-        h_nsn, d_nsv, d_x, d_gap_s,
-        h_xmin, h_ymin, h_zmin, h_xmax, h_ymax, h_zmax,
-        h_xminb, h_yminb, h_zminb, h_xmaxb, h_ymaxb, h_zmaxb,
-        h_nbx, h_nby, h_nbz,
-        d_voxel, d_next_nod
-    );
-    CUDA_CHECK(cudaGetLastError());
-    CUDA_CHECK(cudaDeviceSynchronize());
+    (void)nsn; (void)nsnr; (void)nbx; (void)nby; (void)nbz;
+    (void)nrtm; (void)numnod; (void)nsv; (void)x; (void)stfn; (void)box_limit;
 }
 
 /* ------------------------------------------------------------------ */
 void inter7_gpu_candidate_pairs_(
-    const int*       nsn,
-    const int*       nrtm,
-    const int*       numnod,
-    const int*       nsv,
-    const int*       irect,
+    const int*         nsn,
+    const int*         nrtm,
+    const int*         numnod,
+    const int*         nsv,
+    const int*         irect,
     const my_real_gpu* x,
+    const my_real_gpu* stfn,      /* slave node stiffness [nsn] */
     const my_real_gpu* stf,
     const my_real_gpu* xyzm,
-    const int*       voxel,
-    const int*       next_nod,
-    const int*       nsnr,
-    const int*       nbx,
-    const int*       nby,
-    const int*       nbz,
-    const int*       igap,
+    const int*         voxel,
+    const int*         next_nod,
+    const int*         nsnr,
+    const int*         nbx, const int* nby, const int* nbz,
+    const int*         igap,
     const my_real_gpu* marge,
     const my_real_gpu* tzinf,
     const my_real_gpu* gap,
@@ -642,102 +500,237 @@ void inter7_gpu_candidate_pairs_(
     const my_real_gpu* gap_s,
     const my_real_gpu* gap_m,
     const my_real_gpu* curv_max,
-    const int*       flagremnode,
-    const int*       s_kremnod,
-    const int*       kremnod,
-    const int*       s_remnod,
-    const int*       remnod,
-    const int*       mulnsn,
-    int*             cand_n,
-    int*             cand_e,
-    int*             ii_stok
+    const int*         flagremnode,
+    const int*         s_kremnod,
+    const int*         kremnod,
+    const int*         s_remnod,
+    const int*         remnod,
+    const int*         mulnsn,
+    int*               cand_n,
+    int*               cand_e,
+    int*               ii_stok
 )
 {
+    (void)xyzm; (void)voxel; (void)next_nod;
+    (void)nbx; (void)nby; (void)nbz; (void)gap;
+
     if (!g_initialised) return;
-
-    int h_nsn    = *nsn,    h_nrtm   = *nrtm;
-    int h_numnod = *numnod, h_nsnr   = *nsnr;
-    int h_nbx    = *nbx,    h_nby    = *nby,    h_nbz    = *nbz;
+    int h_nsn    = *nsn,  h_nrtm  = *nrtm, h_numnod = *numnod;
     int h_mulnsn = *mulnsn;
-    int h_flagrn = *flagremnode;
-    int h_igap   = *igap;
 
-    if (h_nrtm == 0 || h_nsn == 0) { *ii_stok = 0; return; }
+    if (h_nsn == 0 || h_nrtm == 0) { *ii_stok = 0; return; }
 
-    int voxel_sz = (h_nbx + 2) * (h_nby + 2) * (h_nbz + 2);
-    int nod_sz   = h_nsn + h_nsnr;
-
-    /* ---- Reallocate device buffers ---- */
-    ensure_device_int(&d_voxel,     &g_sz_voxel,  voxel_sz);
-    ensure_device_int(&d_next_nod,  &g_sz_nod,    nod_sz);
-    ensure_device_int(&d_nsv,       &g_sz_nod,    h_nsn);
-    ensure_device_int(&d_irect,     &g_sz_nrtm,   4 * h_nrtm);
-    ensure_device_int(&d_cand_n,    &g_sz_cand,   h_mulnsn);
-    ensure_device_int(&d_cand_e,    &g_sz_cand,   h_mulnsn);
+    /* ---- upload geometry to device ---- */
     ensure_device_real(&d_x,        &g_sz_numnod, 3 * h_numnod);
+    ensure_device_int (&d_nsv,      &g_sz_nsn,    h_nsn);
+    ensure_device_real(&d_stfn,     &g_sz_nsn,    h_nsn);
+    ensure_device_real(&d_gap_s,    &g_sz_nsn,    h_nsn);
+    ensure_device_int (&d_irect,    &g_sz_nrtm,   4 * h_nrtm);
     ensure_device_real(&d_stf,      &g_sz_nrtm,   h_nrtm);
-    ensure_device_real(&d_gap_s,    &g_sz_nod,    h_nsn);
     ensure_device_real(&d_gap_m,    &g_sz_nrtm,   h_nrtm);
     ensure_device_real(&d_curv_max, &g_sz_nrtm,   h_nrtm);
+    ensure_device_int (&d_kremnod,  &g_sz_kremnod, max(*s_kremnod, 1));
+    ensure_device_int (&d_remnod,   &g_sz_remnod,  max(*s_remnod,  1));
+    ensure_device_int (&d_cand_n,   &g_sz_cand,   h_mulnsn);
+    ensure_device_int (&d_cand_e,   &g_sz_cand,   h_mulnsn);
 
-    /* KREMNODE CSR */
-    int h_s_kremnod = *s_kremnod;
-    int h_s_remnod  = *s_remnod;
-    ensure_device_int(&d_kremnod, &g_sz_kremnod, max(h_s_kremnod, 1));
-    ensure_device_int(&d_remnod,  &g_sz_remnod,  max(h_s_remnod,  1));
+    CUDA_CHECK(cudaMemcpy(d_x,        x,        3*h_numnod*sizeof(my_real_gpu), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_nsv,      nsv,      h_nsn    *sizeof(int),          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_stfn,     stfn,     h_nsn    *sizeof(my_real_gpu),  cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_gap_s,    gap_s,    h_nsn    *sizeof(my_real_gpu),  cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_irect,    irect,    4*h_nrtm *sizeof(int),          cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_stf,      stf,      h_nrtm   *sizeof(my_real_gpu),  cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_gap_m,    gap_m,    h_nrtm   *sizeof(my_real_gpu),  cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_curv_max, curv_max, h_nrtm   *sizeof(my_real_gpu),  cudaMemcpyHostToDevice));
+    if (*s_kremnod > 0)
+        CUDA_CHECK(cudaMemcpy(d_kremnod, kremnod, (*s_kremnod)*sizeof(int), cudaMemcpyHostToDevice));
+    if (*s_remnod > 0)
+        CUDA_CHECK(cudaMemcpy(d_remnod,  remnod,  (*s_remnod) *sizeof(int), cudaMemcpyHostToDevice));
 
-    /* ---- Upload host → device ---- */
-    CUDA_CHECK(cudaMemcpy(d_voxel,    voxel,    (size_t)voxel_sz * sizeof(int),       cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(d_next_nod, next_nod, (size_t)nod_sz   * sizeof(int),       cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(d_nsv,      nsv,      (size_t)h_nsn    * sizeof(int),       cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(d_irect,    irect,    (size_t)4*h_nrtm * sizeof(int),       cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(d_x,        x,        (size_t)3*h_numnod*sizeof(my_real_gpu),cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(d_stf,      stf,      (size_t)h_nrtm   * sizeof(my_real_gpu),cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(d_gap_s,    gap_s,    (size_t)h_nsn    * sizeof(my_real_gpu),cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(d_gap_m,    gap_m,    (size_t)h_nrtm   * sizeof(my_real_gpu),cudaMemcpyHostToDevice));
-    CUDA_CHECK(cudaMemcpy(d_curv_max, curv_max, (size_t)h_nrtm   * sizeof(my_real_gpu),cudaMemcpyHostToDevice));
-    if (h_s_kremnod > 0)
-        CUDA_CHECK(cudaMemcpy(d_kremnod, kremnod, (size_t)h_s_kremnod * sizeof(int), cudaMemcpyHostToDevice));
-    if (h_s_remnod > 0)
-        CUDA_CHECK(cudaMemcpy(d_remnod,  remnod,  (size_t)h_s_remnod  * sizeof(int), cudaMemcpyHostToDevice));
+    /* ---- Step 1: slave point AABBs ---- */
+    ensure_device_aabb(&d_slave_aabbs,  &g_sz_slave_aabbs, h_nsn);
+    ensure_device_int (&d_slave_active, &g_sz_slave_act,   h_nsn);
+    {
+        int threads = 256, blocks = (h_nsn + threads-1)/threads;
+        kernel_build_slave_aabbs<<<blocks, threads>>>(
+            h_nsn, d_nsv, d_x, d_stfn, d_slave_aabbs, d_slave_active);
+        CUDA_CHECK(cudaGetLastError());
+    }
 
-    /* Reset output counter */
-    CUDA_CHECK(cudaMemset(d_counter, 0, sizeof(int)));
-
-    /*
-     * xyzm layout (Fortran inter7_candidate_pairs.F90):
-     *   xyzm(1..6)  = xmin,ymin,zmin,xmax,ymax,zmax
-     *   xyzm(7..12) = xminb,yminb,zminb,xmaxb,ymaxb,zmaxb
-     * In C (0-based): xyzm[0..5], xyzm[6..11]
-     */
-    my_real_gpu h_xminb = xyzm[6],  h_yminb = xyzm[7],  h_zminb = xyzm[8];
-    my_real_gpu h_xmaxb = xyzm[9],  h_ymaxb = xyzm[10], h_zmaxb = xyzm[11];
-
-    /* ---- Launch candidate kernel: one block per segment ---- */
-    kernel_candidate_pairs<<<h_nrtm, BLOCK_SIZE>>>(
-        h_nrtm, h_nsn,
-        d_irect, d_x, d_nsv,
-        d_voxel, d_next_nod,
-        h_xminb, h_yminb, h_zminb,
-        h_xmaxb, h_ymaxb, h_zmaxb,
-        h_nbx, h_nby, h_nbz,
-        h_igap,
-        *marge, *tzinf, *gap, *gapmin, *gapmax, *bgapsmx, *drad, *dgapload,
-        d_gap_s, d_gap_m, d_curv_max, d_stf,
-        h_flagrn, d_kremnod, d_remnod,
-        d_cand_n, d_cand_e, d_counter, h_mulnsn
-    );
-    CUDA_CHECK(cudaGetLastError());
+    /* ---- Step 2: segment inflated AABBs ---- */
+    ensure_device_aabb(&d_segment_aabbs, &g_sz_segment_aabbs, h_nrtm);
+    ensure_device_int (&d_seg_active,    &g_sz_seg_act,       h_nrtm);
+    {
+        int threads = 256, blocks = (h_nrtm + threads-1)/threads;
+        kernel_build_segment_aabbs<<<blocks, threads>>>(
+            h_nrtm, d_irect, d_x, d_stf, d_gap_m, d_curv_max,
+            *marge, *tzinf, *gapmin, *gapmax, *bgapsmx, *dgapload, *drad, *igap,
+            d_segment_aabbs, d_seg_active);
+        CUDA_CHECK(cudaGetLastError());
+    }
     CUDA_CHECK(cudaDeviceSynchronize());
 
-    /* ---- Read back results ---- */
-    int h_count = 0;
-    CUDA_CHECK(cudaMemcpy(&h_count, d_counter, sizeof(int), cudaMemcpyDeviceToHost));
-    h_count = min(h_count, h_mulnsn);
+    /* ---- Download AABB data to host for PhysX submission ---- */
+    ensure_host_raw((void**)&h_slave_aabbs,   &h_sz_sa_bytes,    h_nsn  *sizeof(AabbEntry));
+    ensure_host_raw((void**)&h_segment_aabbs, &h_sz_seg_bytes,   h_nrtm *sizeof(AabbEntry));
+    ensure_host_raw((void**)&h_slave_active,  &h_sz_sact_bytes,  h_nsn  *sizeof(int));
+    ensure_host_raw((void**)&h_seg_active,    &h_sz_seact_bytes, h_nrtm *sizeof(int));
 
-    if (h_count > 0) {
-        CUDA_CHECK(cudaMemcpy(cand_n, d_cand_n, (size_t)h_count * sizeof(int), cudaMemcpyDeviceToHost));
-        CUDA_CHECK(cudaMemcpy(cand_e, d_cand_e, (size_t)h_count * sizeof(int), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_slave_aabbs,   d_slave_aabbs,   h_nsn *sizeof(AabbEntry), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_segment_aabbs, d_segment_aabbs, h_nrtm*sizeof(AabbEntry), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_slave_active,  d_slave_active,  h_nsn *sizeof(int),       cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(h_seg_active,    d_seg_active,    h_nrtm*sizeof(int),       cudaMemcpyDeviceToHost));
+
+    /* ---- Step 3: submit to PhysX GPU broad phase ----
+     *
+     * PxBroadPhaseUpdateData uses HANDLE-INDEXED arrays:
+     *   mBounds[handle] and mGroups[handle] are accessed for each handle
+     *   listed in mCreated[].
+     *
+     * Handle assignment:
+     *   slave i   → handle = i          (0 .. nsn-1)
+     *   segment ne → handle = nsn + ne  (nsn .. nsn+nrtm-1)
+     *
+     * Capacity = nsn + nrtm (one past the last handle).
+     */
+    int total_objs = h_nsn + h_nrtm;
+
+    /* Handle-indexed arrays, capacity = total_objs */
+    ensure_host_raw((void**)&h_bounds,  &h_sz_bnd_bytes, total_objs * (int)sizeof(AabbEntry));
+    ensure_host_raw((void**)&h_groups,  &h_sz_grp_bytes, total_objs * (int)sizeof(PxU32));
+    ensure_host_raw((void**)&h_created, &h_sz_cr_bytes,  total_objs * (int)sizeof(PxU32));
+
+    PxU32 n_created = 0;
+
+    for (int i = 0; i < h_nsn; i++) {
+        if (!h_slave_active[i]) continue;
+        PxU32 handle = (PxU32)i;
+        h_bounds[handle] = h_slave_aabbs[i];
+        h_groups[handle] = FILTER_SLAVE;
+        h_created[n_created++] = handle;
     }
-    *ii_stok = h_count;
+    for (int ne = 0; ne < h_nrtm; ne++) {
+        if (!h_seg_active[ne]) continue;
+        PxU32 handle = (PxU32)(h_nsn + ne);
+        h_bounds[handle] = h_segment_aabbs[ne];
+        h_groups[handle] = FILTER_MASTER;
+        h_created[n_created++] = handle;
+    }
+
+    if (n_created == 0) { *ii_stok = 0; return; }
+
+    /* PhysX 5.x PxBroadPhaseUpdateData constructor:
+     *   (created, nbCreated, updated, nbUpdated, removed, nbRemoved,
+     *    bounds, groups, distances=NULL, capacity=0)
+     * mBounds is cast from AabbEntry* because AabbEntry == PxBounds3 layout. */
+    PxBroadPhaseUpdateData addData(
+        h_created, n_created,
+        nullptr,   0,
+        nullptr,   0,
+        reinterpret_cast<const PxBounds3*>(h_bounds),
+        h_groups,
+        nullptr,
+        (PxU32)total_objs
+    );
+    g_broadPhase->update(addData);
+
+    PxBroadPhaseResults results;
+    g_broadPhase->fetchResults(results);
+
+    PxU32 npairs = results.mNbCreatedPairs;
+    if (npairs == 0) {
+        /* Remove objects so handles are free for the next call */
+        goto remove_and_return_zero;
+    }
+
+    /* ---- Unpack PhysX pairs ---- */
+    ensure_host_raw((void**)&h_pair_slave, &h_sz_ps_bytes, (int)npairs * (int)sizeof(int));
+    ensure_host_raw((void**)&h_pair_seg,   &h_sz_pe_bytes, (int)npairs * (int)sizeof(int));
+
+    {
+        PxU32 valid = 0;
+        for (PxU32 k = 0; k < npairs; k++) {
+            PxU32 h0 = results.mCreatedPairs[k].mID0;
+            PxU32 h1 = results.mCreatedPairs[k].mID1;
+            /* Identify slave vs segment by handle range */
+            PxU32 slave_handle, seg_handle;
+            if (h0 < (PxU32)h_nsn) { slave_handle = h0; seg_handle = h1; }
+            else                    { slave_handle = h1; seg_handle = h0; }
+            if (seg_handle < (PxU32)h_nsn ||
+                seg_handle >= (PxU32)(h_nsn + h_nrtm)) continue;
+            h_pair_slave[valid] = (int)slave_handle;
+            h_pair_seg[valid]   = (int)(seg_handle - h_nsn);
+            valid++;
+        }
+
+        if (valid == 0) goto remove_and_return_zero;
+
+        ensure_device_int(&d_pair_slave, &g_sz_pairs_d, (int)valid);
+        ensure_device_int(&d_pair_seg,   &g_sz_pairs_d, (int)valid);
+        CUDA_CHECK(cudaMemcpy(d_pair_slave, h_pair_slave, valid*sizeof(int), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(d_pair_seg,   h_pair_seg,   valid*sizeof(int), cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemset(d_counter, 0, sizeof(int)));
+
+        /* ---- Step 4: post-filter on GPU ---- */
+        {
+            int threads = 256, blocks = ((int)valid + threads - 1) / threads;
+            kernel_postfilter_pairs<<<blocks, threads>>>(
+                (int)valid,
+                d_pair_slave, d_pair_seg,
+                h_nrtm, d_irect, d_x, d_nsv,
+                *igap, *marge, *gapmin, *gapmax, *dgapload, *drad,
+                d_gap_s, d_gap_m, d_curv_max,
+                *flagremnode, d_kremnod, d_remnod,
+                d_cand_n, d_cand_e, d_counter, h_mulnsn);
+            CUDA_CHECK(cudaGetLastError());
+            CUDA_CHECK(cudaDeviceSynchronize());
+        }
+
+        int h_count = 0;
+        CUDA_CHECK(cudaMemcpy(&h_count, d_counter, sizeof(int), cudaMemcpyDeviceToHost));
+        h_count = min(h_count, h_mulnsn);
+        if (h_count > 0) {
+            CUDA_CHECK(cudaMemcpy(cand_n, d_cand_n, h_count*sizeof(int), cudaMemcpyDeviceToHost));
+            CUDA_CHECK(cudaMemcpy(cand_e, d_cand_e, h_count*sizeof(int), cudaMemcpyDeviceToHost));
+        }
+        *ii_stok = h_count;
+    }
+
+    /* ---- Remove all objects so handles are free for the next call ---- */
+    {
+        ensure_host_raw((void**)&h_removed, &h_sz_rm_bytes, (int)n_created * (int)sizeof(PxU32));
+        memcpy(h_removed, h_created, n_created * sizeof(PxU32));
+        PxBroadPhaseUpdateData removeData(
+            nullptr,   0,
+            nullptr,   0,
+            h_removed, n_created,
+            reinterpret_cast<const PxBounds3*>(h_bounds),
+            h_groups,
+            nullptr,
+            (PxU32)total_objs
+        );
+        g_broadPhase->update(removeData);
+        PxBroadPhaseResults dummy;
+        g_broadPhase->fetchResults(dummy);
+    }
+    return;
+
+remove_and_return_zero:
+    *ii_stok = 0;
+    {
+        ensure_host_raw((void**)&h_removed, &h_sz_rm_bytes, (int)n_created * (int)sizeof(PxU32));
+        memcpy(h_removed, h_created, n_created * sizeof(PxU32));
+        PxBroadPhaseUpdateData removeData(
+            nullptr,   0,
+            nullptr,   0,
+            h_removed, n_created,
+            reinterpret_cast<const PxBounds3*>(h_bounds),
+            h_groups,
+            nullptr,
+            (PxU32)total_objs
+        );
+        g_broadPhase->update(removeData);
+        PxBroadPhaseResults dummy;
+        g_broadPhase->fetchResults(dummy);
+    }
 }

--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
@@ -49,8 +49,10 @@ Copyright>        along with this program.  If not, see <https://www.gnu.org/lic
  *
  * Step 3  PxBroadPhase::update()  (GPU, inside PhysX)
  *   Objects are submitted via PxBroadPhaseUpdateData with handle-indexed
- *   mBounds and mGroups arrays.  PhysX Sort-and-Prune on the GPU finds all
- *   overlapping (slave, master) AABB pairs.
+ *   mBounds and mGroups arrays (capacity = nsn + nrtm).
+ *   Handle assignment: slave i → handle i; segment ne → handle nsn+ne.
+ *   PhysX Sort-and-Prune on the GPU finds all overlapping (slave, master)
+ *   AABB pairs.
  *
  * Step 4  postfilter_pairs  (CUDA kernel, one thread per PhysX pair)
  *   For each pair (slave_idx, segment_idx) returned by PhysX, apply:
@@ -78,12 +80,20 @@ Copyright>        along with this program.  If not, see <https://www.gnu.org/lic
  * - We rebuild all objects every timestep (remove-then-add) so that
  *   fetchResults().mCreatedPairs contains all current overlaps.
  *   An incremental update-only approach would miss pre-existing contacts.
+ *
+ * SPMD / MPI limitation
+ * =====================
+ * The GPU path only processes local slave nodes (indices 1..nsn in NSV).
+ * Remote slave nodes from other MPI ranks (nsnr > 0) are not submitted
+ * to the GPU broad phase.  The caller is responsible for handling remote
+ * nodes via the CPU fallback path when nsnr > 0.
  */
 
 #include "inter7_gpu_broadphase.h"
 
 #include <PxPhysicsAPI.h>
 #include <cuda_runtime.h>
+#include <algorithm>
 #include <stdio.h>
 #include <string.h>
 
@@ -108,8 +118,14 @@ using namespace physx;
 
 /* ------------------------------------------------------------------ */
 /* Buffer helpers                                                      */
+/*                                                                     */
+/* IMPORTANT: every device pointer must have its OWN dedicated size    */
+/* tracker.  Sharing a size tracker between two pointers of the same   */
+/* size causes the second ensure_* call to skip allocation, leaving    */
+/* the second pointer null.                                            */
 /* ------------------------------------------------------------------ */
-/* Device buffers */
+
+/* Device buffers – each gets its own size counter */
 static void ensure_device_int(int** p, int* sz, int n)
 {
     if (n > *sz) {
@@ -161,30 +177,34 @@ static PxCudaContextManager*    g_cudaCtxMgr = nullptr;
 static PxBroadPhase*            g_broadPhase = nullptr;  /* eGPU */
 static bool                     g_initialised = false;
 
-/* Device buffers (persistent across calls, grown on demand) */
-static my_real_gpu* d_x        = nullptr;  static int g_sz_numnod  = 0;
-static int*         d_nsv      = nullptr;  static int g_sz_nsn     = 0;
-static my_real_gpu* d_stfn     = nullptr;  /* slave stiffness, shares g_sz_nsn */
-static my_real_gpu* d_gap_s    = nullptr;  /* slave gap, shares g_sz_nsn */
-static int*         d_irect    = nullptr;  static int g_sz_nrtm    = 0;
-static my_real_gpu* d_stf      = nullptr;  /* segment stiffness, shares g_sz_nrtm */
-static my_real_gpu* d_gap_m    = nullptr;  /* segment gap, shares g_sz_nrtm */
-static my_real_gpu* d_curv_max = nullptr;  /* curvature, shares g_sz_nrtm */
-static int*         d_kremnod  = nullptr;  static int g_sz_kremnod = 0;
-static int*         d_remnod   = nullptr;  static int g_sz_remnod  = 0;
-static int*         d_cand_n   = nullptr;  static int g_sz_cand    = 0;
-static int*         d_cand_e   = nullptr;
+/*
+ * Device buffers – persistent, grown on demand.
+ * Each pointer has its OWN dedicated size tracker to avoid the shared-
+ * tracker aliasing bug (see ensure_device_* note above).
+ */
+static my_real_gpu* d_x        = nullptr;  static int g_sz_x        = 0;
+static int*         d_nsv      = nullptr;  static int g_sz_nsv      = 0;
+static my_real_gpu* d_stfn     = nullptr;  static int g_sz_stfn     = 0;
+static my_real_gpu* d_gap_s    = nullptr;  static int g_sz_gap_s    = 0;
+static int*         d_irect    = nullptr;  static int g_sz_irect    = 0;
+static my_real_gpu* d_stf      = nullptr;  static int g_sz_stf      = 0;
+static my_real_gpu* d_gap_m    = nullptr;  static int g_sz_gap_m    = 0;
+static my_real_gpu* d_curv_max = nullptr;  static int g_sz_curv_max = 0;
+static int*         d_kremnod  = nullptr;  static int g_sz_kremnod  = 0;
+static int*         d_remnod   = nullptr;  static int g_sz_remnod   = 0;
+static int*         d_cand_n   = nullptr;  static int g_sz_cand_n   = 0;
+static int*         d_cand_e   = nullptr;  static int g_sz_cand_e   = 0;
 static int*         d_counter  = nullptr;
 
 /* GPU AABB arrays */
-static AabbEntry*   d_slave_aabbs   = nullptr;  static int g_sz_slave_aabbs   = 0;
-static AabbEntry*   d_segment_aabbs = nullptr;  static int g_sz_segment_aabbs = 0;
-static int*         d_slave_active  = nullptr;  static int g_sz_slave_act     = 0;
-static int*         d_seg_active    = nullptr;  static int g_sz_seg_act       = 0;
+static AabbEntry*   d_slave_aabbs   = nullptr;  static int g_sz_slave_aabbs = 0;
+static AabbEntry*   d_segment_aabbs = nullptr;  static int g_sz_seg_aabbs   = 0;
+static int*         d_slave_active  = nullptr;  static int g_sz_slave_act   = 0;
+static int*         d_seg_active    = nullptr;  static int g_sz_seg_act     = 0;
 
-/* GPU pair arrays (post PhysX) */
-static int*         d_pair_slave    = nullptr;  static int g_sz_pairs_d       = 0;
-static int*         d_pair_seg      = nullptr;
+/* GPU pair arrays (post PhysX, pre post-filter) */
+static int*         d_pair_slave    = nullptr;  static int g_sz_pair_slave  = 0;
+static int*         d_pair_seg      = nullptr;  static int g_sz_pair_seg    = 0;
 
 /* ---- Host arrays ---- */
 
@@ -411,6 +431,8 @@ int inter7_gpu_broadphase_init_(void)
                                                PxGetProfilerCallback());
     if (!g_cudaCtxMgr || !g_cudaCtxMgr->contextIsValid()) {
         fprintf(stderr, "[GPU BPH] CUDA context init failed.\n");
+        /* Release everything allocated so far before returning */
+        if (g_cudaCtxMgr) { g_cudaCtxMgr->release(); g_cudaCtxMgr = nullptr; }
         g_foundation->release(); g_foundation = nullptr;
         return 1;
     }
@@ -520,19 +542,21 @@ void inter7_gpu_candidate_pairs_(
 
     if (h_nsn == 0 || h_nrtm == 0) { *ii_stok = 0; return; }
 
-    /* ---- upload geometry to device ---- */
-    ensure_device_real(&d_x,        &g_sz_numnod, 3 * h_numnod);
-    ensure_device_int (&d_nsv,      &g_sz_nsn,    h_nsn);
-    ensure_device_real(&d_stfn,     &g_sz_nsn,    h_nsn);
-    ensure_device_real(&d_gap_s,    &g_sz_nsn,    h_nsn);
-    ensure_device_int (&d_irect,    &g_sz_nrtm,   4 * h_nrtm);
-    ensure_device_real(&d_stf,      &g_sz_nrtm,   h_nrtm);
-    ensure_device_real(&d_gap_m,    &g_sz_nrtm,   h_nrtm);
-    ensure_device_real(&d_curv_max, &g_sz_nrtm,   h_nrtm);
-    ensure_device_int (&d_kremnod,  &g_sz_kremnod, max(*s_kremnod, 1));
-    ensure_device_int (&d_remnod,   &g_sz_remnod,  max(*s_remnod,  1));
-    ensure_device_int (&d_cand_n,   &g_sz_cand,   h_mulnsn);
-    ensure_device_int (&d_cand_e,   &g_sz_cand,   h_mulnsn);
+    /* ---- upload geometry to device ----
+     * Each pointer uses its OWN size tracker so that ensure_device_* always
+     * allocates correctly even when multiple buffers have the same element count. */
+    ensure_device_real(&d_x,        &g_sz_x,        3 * h_numnod);
+    ensure_device_int (&d_nsv,      &g_sz_nsv,      h_nsn);
+    ensure_device_real(&d_stfn,     &g_sz_stfn,     h_nsn);
+    ensure_device_real(&d_gap_s,    &g_sz_gap_s,    h_nsn);
+    ensure_device_int (&d_irect,    &g_sz_irect,    4 * h_nrtm);
+    ensure_device_real(&d_stf,      &g_sz_stf,      h_nrtm);
+    ensure_device_real(&d_gap_m,    &g_sz_gap_m,    h_nrtm);
+    ensure_device_real(&d_curv_max, &g_sz_curv_max, h_nrtm);
+    ensure_device_int (&d_kremnod,  &g_sz_kremnod,  (*s_kremnod > 0 ? *s_kremnod : 1));
+    ensure_device_int (&d_remnod,   &g_sz_remnod,   (*s_remnod  > 0 ? *s_remnod  : 1));
+    ensure_device_int (&d_cand_n,   &g_sz_cand_n,   h_mulnsn);
+    ensure_device_int (&d_cand_e,   &g_sz_cand_e,   h_mulnsn);
 
     CUDA_CHECK(cudaMemcpy(d_x,        x,        3*h_numnod*sizeof(my_real_gpu), cudaMemcpyHostToDevice));
     CUDA_CHECK(cudaMemcpy(d_nsv,      nsv,      h_nsn    *sizeof(int),          cudaMemcpyHostToDevice));
@@ -558,8 +582,8 @@ void inter7_gpu_candidate_pairs_(
     }
 
     /* ---- Step 2: segment inflated AABBs ---- */
-    ensure_device_aabb(&d_segment_aabbs, &g_sz_segment_aabbs, h_nrtm);
-    ensure_device_int (&d_seg_active,    &g_sz_seg_act,       h_nrtm);
+    ensure_device_aabb(&d_segment_aabbs, &g_sz_seg_aabbs, h_nrtm);
+    ensure_device_int (&d_seg_active,    &g_sz_seg_act,   h_nrtm);
     {
         int threads = 256, blocks = (h_nrtm + threads-1)/threads;
         kernel_build_segment_aabbs<<<blocks, threads>>>(
@@ -588,14 +612,13 @@ void inter7_gpu_candidate_pairs_(
      *   listed in mCreated[].
      *
      * Handle assignment:
-     *   slave i   → handle = i          (0 .. nsn-1)
-     *   segment ne → handle = nsn + ne  (nsn .. nsn+nrtm-1)
+     *   slave i    → handle = i          (0 .. nsn-1)
+     *   segment ne → handle = nsn + ne   (nsn .. nsn+nrtm-1)
      *
      * Capacity = nsn + nrtm (one past the last handle).
      */
     int total_objs = h_nsn + h_nrtm;
 
-    /* Handle-indexed arrays, capacity = total_objs */
     ensure_host_raw((void**)&h_bounds,  &h_sz_bnd_bytes, total_objs * (int)sizeof(AabbEntry));
     ensure_host_raw((void**)&h_groups,  &h_sz_grp_bytes, total_objs * (int)sizeof(PxU32));
     ensure_host_raw((void**)&h_created, &h_sz_cr_bytes,  total_objs * (int)sizeof(PxU32));
@@ -621,8 +644,8 @@ void inter7_gpu_candidate_pairs_(
 
     /* PhysX 5.x PxBroadPhaseUpdateData constructor:
      *   (created, nbCreated, updated, nbUpdated, removed, nbRemoved,
-     *    bounds, groups, distances=NULL, capacity=0)
-     * mBounds is cast from AabbEntry* because AabbEntry == PxBounds3 layout. */
+     *    bounds, groups, distances=NULL, capacity)
+     * mBounds cast from AabbEntry* because AabbEntry == PxBounds3 layout. */
     PxBroadPhaseUpdateData addData(
         h_created, n_created,
         nullptr,   0,
@@ -638,99 +661,80 @@ void inter7_gpu_candidate_pairs_(
     g_broadPhase->fetchResults(results);
 
     PxU32 npairs = results.mNbCreatedPairs;
+
+    /* Prepare cleanup update data (used whether or not there are pairs) */
+    ensure_host_raw((void**)&h_removed, &h_sz_rm_bytes, (int)n_created * (int)sizeof(PxU32));
+    memcpy(h_removed, h_created, n_created * sizeof(PxU32));
+    PxBroadPhaseUpdateData removeData(
+        nullptr,   0,
+        nullptr,   0,
+        h_removed, n_created,
+        reinterpret_cast<const PxBounds3*>(h_bounds),
+        h_groups,
+        nullptr,
+        (PxU32)total_objs
+    );
+
     if (npairs == 0) {
-        /* Remove objects so handles are free for the next call */
-        goto remove_and_return_zero;
+        *ii_stok = 0;
+        g_broadPhase->update(removeData);
+        PxBroadPhaseResults dummy; g_broadPhase->fetchResults(dummy);
+        return;
     }
 
     /* ---- Unpack PhysX pairs ---- */
     ensure_host_raw((void**)&h_pair_slave, &h_sz_ps_bytes, (int)npairs * (int)sizeof(int));
     ensure_host_raw((void**)&h_pair_seg,   &h_sz_pe_bytes, (int)npairs * (int)sizeof(int));
 
-    {
-        PxU32 valid = 0;
-        for (PxU32 k = 0; k < npairs; k++) {
-            PxU32 h0 = results.mCreatedPairs[k].mID0;
-            PxU32 h1 = results.mCreatedPairs[k].mID1;
-            /* Identify slave vs segment by handle range */
-            PxU32 slave_handle, seg_handle;
-            if (h0 < (PxU32)h_nsn) { slave_handle = h0; seg_handle = h1; }
-            else                    { slave_handle = h1; seg_handle = h0; }
-            if (seg_handle < (PxU32)h_nsn ||
-                seg_handle >= (PxU32)(h_nsn + h_nrtm)) continue;
-            h_pair_slave[valid] = (int)slave_handle;
-            h_pair_seg[valid]   = (int)(seg_handle - h_nsn);
-            valid++;
-        }
-
-        if (valid == 0) goto remove_and_return_zero;
-
-        ensure_device_int(&d_pair_slave, &g_sz_pairs_d, (int)valid);
-        ensure_device_int(&d_pair_seg,   &g_sz_pairs_d, (int)valid);
-        CUDA_CHECK(cudaMemcpy(d_pair_slave, h_pair_slave, valid*sizeof(int), cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemcpy(d_pair_seg,   h_pair_seg,   valid*sizeof(int), cudaMemcpyHostToDevice));
-        CUDA_CHECK(cudaMemset(d_counter, 0, sizeof(int)));
-
-        /* ---- Step 4: post-filter on GPU ---- */
-        {
-            int threads = 256, blocks = ((int)valid + threads - 1) / threads;
-            kernel_postfilter_pairs<<<blocks, threads>>>(
-                (int)valid,
-                d_pair_slave, d_pair_seg,
-                h_nrtm, d_irect, d_x, d_nsv,
-                *igap, *marge, *gapmin, *gapmax, *dgapload, *drad,
-                d_gap_s, d_gap_m, d_curv_max,
-                *flagremnode, d_kremnod, d_remnod,
-                d_cand_n, d_cand_e, d_counter, h_mulnsn);
-            CUDA_CHECK(cudaGetLastError());
-            CUDA_CHECK(cudaDeviceSynchronize());
-        }
-
-        int h_count = 0;
-        CUDA_CHECK(cudaMemcpy(&h_count, d_counter, sizeof(int), cudaMemcpyDeviceToHost));
-        h_count = min(h_count, h_mulnsn);
-        if (h_count > 0) {
-            CUDA_CHECK(cudaMemcpy(cand_n, d_cand_n, h_count*sizeof(int), cudaMemcpyDeviceToHost));
-            CUDA_CHECK(cudaMemcpy(cand_e, d_cand_e, h_count*sizeof(int), cudaMemcpyDeviceToHost));
-        }
-        *ii_stok = h_count;
+    PxU32 valid = 0;
+    for (PxU32 k = 0; k < npairs; k++) {
+        PxU32 h0 = results.mCreatedPairs[k].mID0;
+        PxU32 h1 = results.mCreatedPairs[k].mID1;
+        PxU32 slave_handle, seg_handle;
+        if (h0 < (PxU32)h_nsn) { slave_handle = h0; seg_handle = h1; }
+        else                    { slave_handle = h1; seg_handle = h0; }
+        if (seg_handle < (PxU32)h_nsn ||
+            seg_handle >= (PxU32)(h_nsn + h_nrtm)) continue;
+        h_pair_slave[valid] = (int)slave_handle;
+        h_pair_seg[valid]   = (int)(seg_handle - h_nsn);
+        valid++;
     }
 
-    /* ---- Remove all objects so handles are free for the next call ---- */
-    {
-        ensure_host_raw((void**)&h_removed, &h_sz_rm_bytes, (int)n_created * (int)sizeof(PxU32));
-        memcpy(h_removed, h_created, n_created * sizeof(PxU32));
-        PxBroadPhaseUpdateData removeData(
-            nullptr,   0,
-            nullptr,   0,
-            h_removed, n_created,
-            reinterpret_cast<const PxBounds3*>(h_bounds),
-            h_groups,
-            nullptr,
-            (PxU32)total_objs
-        );
-        g_broadPhase->update(removeData);
-        PxBroadPhaseResults dummy;
-        g_broadPhase->fetchResults(dummy);
-    }
-    return;
+    /* Remove objects before the post-filter so the GPU SAP is clean
+     * regardless of whether post-filter finds any valid pairs. */
+    g_broadPhase->update(removeData);
+    PxBroadPhaseResults dummy; g_broadPhase->fetchResults(dummy);
 
-remove_and_return_zero:
-    *ii_stok = 0;
+    if (valid == 0) { *ii_stok = 0; return; }
+
+    ensure_device_int(&d_pair_slave, &g_sz_pair_slave, (int)valid);
+    ensure_device_int(&d_pair_seg,   &g_sz_pair_seg,   (int)valid);
+    CUDA_CHECK(cudaMemcpy(d_pair_slave, h_pair_slave, valid*sizeof(int), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_pair_seg,   h_pair_seg,   valid*sizeof(int), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemset(d_counter, 0, sizeof(int)));
+
+    /* ---- Step 4: post-filter on GPU ---- */
     {
-        ensure_host_raw((void**)&h_removed, &h_sz_rm_bytes, (int)n_created * (int)sizeof(PxU32));
-        memcpy(h_removed, h_created, n_created * sizeof(PxU32));
-        PxBroadPhaseUpdateData removeData(
-            nullptr,   0,
-            nullptr,   0,
-            h_removed, n_created,
-            reinterpret_cast<const PxBounds3*>(h_bounds),
-            h_groups,
-            nullptr,
-            (PxU32)total_objs
-        );
-        g_broadPhase->update(removeData);
-        PxBroadPhaseResults dummy;
-        g_broadPhase->fetchResults(dummy);
+        int threads = 256, blocks = ((int)valid + threads - 1) / threads;
+        kernel_postfilter_pairs<<<blocks, threads>>>(
+            (int)valid,
+            d_pair_slave, d_pair_seg,
+            h_nrtm, d_irect, d_x, d_nsv,
+            *igap, *marge, *gapmin, *gapmax, *dgapload, *drad,
+            d_gap_s, d_gap_m, d_curv_max,
+            *flagremnode, d_kremnod, d_remnod,
+            d_cand_n, d_cand_e, d_counter, h_mulnsn);
+        CUDA_CHECK(cudaGetLastError());
+        CUDA_CHECK(cudaDeviceSynchronize());
     }
+
+    int h_count = 0;
+    CUDA_CHECK(cudaMemcpy(&h_count, d_counter, sizeof(int), cudaMemcpyDeviceToHost));
+    /* Use std::min – host code cannot use CUDA device intrinsic min() */
+    h_count = std::min(h_count, h_mulnsn);
+    if (h_count > 0) {
+        CUDA_CHECK(cudaMemcpy(cand_n, d_cand_n, h_count*sizeof(int), cudaMemcpyDeviceToHost));
+        CUDA_CHECK(cudaMemcpy(cand_e, d_cand_e, h_count*sizeof(int), cudaMemcpyDeviceToHost));
+    }
+    *ii_stok = h_count;
 }

--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
@@ -17,76 +17,93 @@ Copyright>        along with this program.  If not, see <https://www.gnu.org/lic
 /*
  * inter7_gpu_broadphase.cu
  *
- * GPU broad-phase collision detection using PhysX 5.x PxBroadPhase (eGPU).
+ * GPU broad-phase collision detection using PhysX 5.x PxAABBManager (eGPU).
  *
- * Why PxBroadPhase instead of a custom CUDA voxel kernel
- * =======================================================
- * PhysX ships a GPU-accelerated Sort-and-Prune (SAP) broad phase
- * (PxBroadPhaseType::eGPU) that:
- *   - runs entirely on the GPU via CUDA
- *   - supports incremental updates (only re-sorts objects that moved)
- *   - handles filter groups natively (master/slave asymmetry is free)
- *   - is heavily optimised and validated by NVIDIA
+ * Are our primitives "deformable" in the PhysX sense?
+ * ====================================================
+ * No.  "Deformable" in PhysX refers to PhysX-managed FEM soft bodies, cloth,
+ * or fluid where PhysX owns the vertex positions and updates them internally.
+ * Our slave nodes and master segments are USER-MANAGED AABBs: we compute the
+ * bounding boxes ourselves each timestep and hand them to PhysX.  That is
+ * exactly the purpose of PxAABBManager – it manages a collection of
+ * user-provided AABBs and finds overlaps via the GPU Sort-and-Prune broad
+ * phase.  Nodes whose positions change every FEM timestep are updated via
+ * addObject (in our remove-then-re-add scheme, detailed below).
+ *
+ * Why PxAABBManager instead of PxBroadPhase directly?
+ * ====================================================
+ * PxAABBManager provides a clean object-level API:
+ *   addObject(bounds, filterGroup) → handle
+ *   removeObject(handle)
+ *   update()            ← triggers GPU SAP internally; no data argument
+ *   fetchResults(out)   ← overlap pairs
+ *
+ * PxBroadPhase::update() requires a fully assembled PxBroadPhaseUpdateData
+ * with handle-indexed arrays built on the caller side.  PxAABBManager hides
+ * that bookkeeping.
  *
  * Architecture
  * ============
  *
  * Step 1  build_slave_aabbs  (CUDA kernel, N threads for N slave nodes)
- *   Each slave node i becomes a point AABB [x,x]×[y,y]×[z,z].
+ *   Point AABB [x,x]×[y,y]×[z,z] for each active slave node.
  *   filterGroup = FILTER_SLAVE (0x1)
- *   PhysX suppresses pairs when (A.group & B.group) != 0, so slave–slave
- *   pairs are suppressed and only slave–master pairs are produced.
  *
- * Step 2  build_segment_aabbs  (CUDA kernel, N threads for N segments)
- *   Each master segment ne becomes an inflated AABB:
- *     [xmine - AAA, xmaxe + AAA] in each dimension
- *   where AAA is computed with bgapsmx (overestimation of gap_s).
+ * Step 2  build_segment_aabbs  (CUDA kernel, N threads for N master segments)
+ *   Inflated AABB for each active segment; inflation uses bgapsmx
+ *   (overestimation of gap_s) so the box is conservative (no false negatives).
  *   filterGroup = FILTER_MASTER (0x2)
  *
- *   Using bgapsmx makes the AABB conservative: guaranteed to contain any
- *   slave node that would pass the per-node AABB test (no false negatives).
- *   False positives are removed by the post-filter (Step 4).
- *
- * Step 3  PxBroadPhase::update()  (GPU, inside PhysX)
- *   Objects are submitted via PxBroadPhaseUpdateData with handle-indexed
- *   mBounds and mGroups arrays (capacity = nsn + nrtm).
- *   Handle assignment: slave i → handle i; segment ne → handle nsn+ne.
- *   PhysX Sort-and-Prune on the GPU finds all overlapping (slave, master)
- *   AABB pairs.
+ * Step 3  PxAABBManager add + update  (CPU loop → GPU SAP inside PhysX)
+ *   AABBs are downloaded to host and submitted via addObject().
+ *   update() triggers the GPU Sort-and-Prune.  Only slave–master pairs are
+ *   produced because of the filter groups.
  *
  * Step 4  postfilter_pairs  (CUDA kernel, one thread per PhysX pair)
- *   For each pair (slave_idx, segment_idx) returned by PhysX, apply:
- *   (a) Corner self-pair: node global ID == M1/M2/M3/M4  → reject
- *   (b) KREMNODE forbidden pair: linear scan over per-segment list → reject
- *   (c) Per-node expanded AABB with actual gap_s[slave_idx]         → reject
- *   (d) Plane-distance underestimation (same formula as CPU)        → reject
- *   Valid pairs are written to output arrays via atomicAdd.
+ *   (a) Corner self-pair                                           → reject
+ *   (b) KREMNODE forbidden pair (linear scan, no sort required)    → reject
+ *   (c) Per-node AABB with actual gap_s (not the conservative bgapsmx) → reject
+ *   (d) Plane-distance underestimation (same formula as CPU)       → reject
+ *   Valid pairs written via atomicAdd.
  *
- * Master-surface vs slave-node asymmetry
- * =======================================
- * PhysX filter-group semantics: pair (A,B) suppressed iff (A.group & B.group) != 0.
+ * Filter-group semantics (PhysX)
+ * ================================
+ * Pair (A,B) suppressed iff (A.group & B.group) != 0.
  *   FILTER_SLAVE  = 0x1:  (0x1 & 0x1)=1 → slave-slave suppressed  ✓
  *   FILTER_MASTER = 0x2:  (0x2 & 0x2)=2 → master-master suppressed ✓
  *   slave-master:         (0x1 & 0x2)=0 → pair generated           ✓
  *
- * PxBroadPhaseUpdateData API notes (PhysX 5.x)
- * =============================================
- * - mBounds and mGroups are handle-indexed arrays of capacity mCapacity.
- *   If handle h is in mCreated, then mBounds[h] and mGroups[h] are read.
- *   The arrays must remain valid until fetchResults() returns.
- * - There is no mEnvIDs field; mCapacity is the array capacity.
- * - We use PxBroadPhase directly (not PxAABBManager) because
- *   PxAABBManager::update() does not accept PxBroadPhaseUpdateData.
- * - We rebuild all objects every timestep (remove-then-add) so that
- *   fetchResults().mCreatedPairs contains all current overlaps.
- *   An incremental update-only approach would miss pre-existing contacts.
+ * Remove-then-re-add invariant
+ * ============================
+ * To get ALL currently overlapping pairs (not just newly started overlaps),
+ * we rebuild the manager's object set every timestep:
+ *
+ *   [start-of-call invariant: manager is empty]
+ *   addObject() for each active slave / segment
+ *   update()         ← GPU SAP; all current overlaps appear as "created"
+ *   fetchResults()
+ *   removeObject() for each added handle
+ *   update() + fetchResults() ← flush pending removes; manager empty again
+ *   [end-of-call invariant: manager is empty]
+ *
+ * An incremental updateObject() approach would miss pre-existing contacts
+ * (they would only appear in mCreatedPairs the first timestep they occur).
+ *
+ * Handle decode table
+ * ===================
+ * addObject() returns opaque PxU32 handles.  We maintain a flat host array
+ * h_decode[] indexed by handle value:
+ *   h_decode[h] > 0  →  slave  with local index (h_decode[h] - 1)
+ *   h_decode[h] < 0  →  segment with local index (-h_decode[h] - 1)
+ * With a fresh (empty) manager and no fragmentation, handles are dense
+ * in [0, n_active).  The table is sized to NSN+NRTM and handles beyond
+ * that range are silently skipped.
  *
  * SPMD / MPI limitation
  * =====================
- * The GPU path only processes local slave nodes (indices 1..nsn in NSV).
- * Remote slave nodes from other MPI ranks (nsnr > 0) are not submitted
- * to the GPU broad phase.  The caller is responsible for handling remote
- * nodes via the CPU fallback path when nsnr > 0.
+ * Only local slave nodes (indices 1..nsn in NSV) are processed.
+ * Remote slave nodes from other MPI ranks (nsnr > 0) are not submitted.
+ * The caller must use the CPU path to cover remote-node contacts.
  */
 
 #include "inter7_gpu_broadphase.h"
@@ -118,14 +135,9 @@ using namespace physx;
 
 /* ------------------------------------------------------------------ */
 /* Buffer helpers                                                      */
-/*                                                                     */
-/* IMPORTANT: every device pointer must have its OWN dedicated size    */
-/* tracker.  Sharing a size tracker between two pointers of the same   */
-/* size causes the second ensure_* call to skip allocation, leaving    */
-/* the second pointer null.                                            */
+/* Each pointer must have its own size tracker – sharing trackers      */
+/* causes the second ensure_* call to skip allocation (n <= *sz).      */
 /* ------------------------------------------------------------------ */
-
-/* Device buffers – each gets its own size counter */
 static void ensure_device_int(int** p, int* sz, int n)
 {
     if (n > *sz) {
@@ -142,8 +154,6 @@ static void ensure_device_real(my_real_gpu** p, int* sz, int n)
         *sz = n;
     }
 }
-
-/* Host buffers – raw bytes, separate size per pointer */
 static void ensure_host_raw(void** p, int* sz_bytes, int nbytes)
 {
     if (nbytes > *sz_bytes) {
@@ -153,9 +163,7 @@ static void ensure_host_raw(void** p, int* sz_bytes, int nbytes)
     }
 }
 
-/* ------------------------------------------------------------------ */
-/* AabbEntry: same memory layout as PxBounds3 (2 × PxVec3 of floats) */
-/* ------------------------------------------------------------------ */
+/* AabbEntry: same memory layout as PxBounds3 */
 struct AabbEntry { float lo[3]; float hi[3]; };
 
 static void ensure_device_aabb(AabbEntry** p, int* sz, int n)
@@ -174,14 +182,11 @@ static PxDefaultAllocator       g_alloc;
 static PxDefaultErrorCallback   g_errcb;
 static PxFoundation*            g_foundation = nullptr;
 static PxCudaContextManager*    g_cudaCtxMgr = nullptr;
-static PxBroadPhase*            g_broadPhase = nullptr;  /* eGPU */
+static PxBroadPhase*            g_broadPhase = nullptr;
+static PxAABBManager*           g_aabbMgr    = nullptr;  /* sits on top of g_broadPhase */
 static bool                     g_initialised = false;
 
-/*
- * Device buffers – persistent, grown on demand.
- * Each pointer has its OWN dedicated size tracker to avoid the shared-
- * tracker aliasing bug (see ensure_device_* note above).
- */
+/* Device buffers (persistent, grown on demand, one size tracker each) */
 static my_real_gpu* d_x        = nullptr;  static int g_sz_x        = 0;
 static int*         d_nsv      = nullptr;  static int g_sz_nsv      = 0;
 static my_real_gpu* d_stfn     = nullptr;  static int g_sz_stfn     = 0;
@@ -202,36 +207,35 @@ static AabbEntry*   d_segment_aabbs = nullptr;  static int g_sz_seg_aabbs   = 0;
 static int*         d_slave_active  = nullptr;  static int g_sz_slave_act   = 0;
 static int*         d_seg_active    = nullptr;  static int g_sz_seg_act     = 0;
 
-/* GPU pair arrays (post PhysX, pre post-filter) */
+/* Post-PhysX pair arrays (device) */
 static int*         d_pair_slave    = nullptr;  static int g_sz_pair_slave  = 0;
 static int*         d_pair_seg      = nullptr;  static int g_sz_pair_seg    = 0;
 
-/* ---- Host arrays ---- */
-
-/* AABB and active masks downloaded from GPU */
+/* Host arrays downloaded from GPU */
 static AabbEntry*   h_slave_aabbs   = nullptr;  static int h_sz_sa_bytes    = 0;
 static AabbEntry*   h_segment_aabbs = nullptr;  static int h_sz_seg_bytes   = 0;
 static int*         h_slave_active  = nullptr;  static int h_sz_sact_bytes  = 0;
 static int*         h_seg_active    = nullptr;  static int h_sz_seact_bytes = 0;
 
 /*
- * PhysX update arrays – HANDLE-INDEXED.
- * h_bounds[handle] and h_groups[handle] must be filled for every handle
- * in h_created[].  Capacity = total_objs = nsn + nrtm.
- * h_bounds has the same memory layout as PxBounds3 (cast is safe).
+ * PxAABBManager handle tracking.
+ * h_added_handles[] stores the handles returned by addObject() this frame.
+ * h_decode[handle]  maps each handle to its primitive:
+ *   > 0  →  slave  index (h_decode[h] - 1)
+ *   < 0  →  segment index (-h_decode[h] - 1)
+ *   = 0  →  unused slot
+ * The table is cleared by zeroing used slots before each remove pass.
  */
-static AabbEntry*   h_bounds  = nullptr;  static int h_sz_bnd_bytes = 0;
-static PxU32*       h_groups  = nullptr;  static int h_sz_grp_bytes = 0;
-static PxU32*       h_created = nullptr;  static int h_sz_cr_bytes  = 0;
-static PxU32*       h_removed = nullptr;  static int h_sz_rm_bytes  = 0;
+static PxU32*  h_added_handles = nullptr;  static int h_sz_ah_bytes  = 0;
+static int*    h_decode        = nullptr;  static int h_sz_dec_bytes = 0;
+static int     h_n_added       = 0;        /* number of objects added this frame */
 
-/* Pair host buffers */
-static int*         h_pair_slave = nullptr;  static int h_sz_ps_bytes = 0;
-static int*         h_pair_seg   = nullptr;  static int h_sz_pe_bytes = 0;
+/* Host pair decode buffers */
+static int*    h_pair_slave    = nullptr;  static int h_sz_ps_bytes  = 0;
+static int*    h_pair_seg      = nullptr;  static int h_sz_pe_bytes  = 0;
 
 /* ================================================================== */
-/* Step 1: build slave-node AABBs                                     */
-/* Point AABB at the node position; inactive if stfn==0.             */
+/* Step 1: build slave-node point AABBs                               */
 /* ================================================================== */
 __global__ void kernel_build_slave_aabbs(
     int                        nsn,
@@ -255,8 +259,7 @@ __global__ void kernel_build_slave_aabbs(
 }
 
 /* ================================================================== */
-/* Step 2: build master-segment AABBs                                 */
-/* Inflated by AAA computed with bgapsmx so the box is conservative. */
+/* Step 2: build master-segment inflated AABBs                        */
 /* ================================================================== */
 __global__ void kernel_build_segment_aabbs(
     int                         nrtm,
@@ -278,7 +281,7 @@ __global__ void kernel_build_segment_aabbs(
     if (stf[ne] == (my_real_gpu)0) { active[ne] = 0; return; }
     active[ne] = 1;
 
-    /* IRECT(4,NRTM) column-major: IRECT(k,ne+1) = irect[ne*4 + k] (0-based k) */
+    /* IRECT(4,NRTM) column-major: IRECT(k,ne+1) = irect[ne*4+k] (0-based k) */
     int m0 = irect[ne*4 + 0] - 1;
     int m1 = irect[ne*4 + 1] - 1;
     int m2 = irect[ne*4 + 2] - 1;
@@ -313,7 +316,7 @@ __global__ void kernel_build_segment_aabbs(
 }
 
 /* ================================================================== */
-/* Step 4: post-filter PhysX pairs                                    */
+/* Step 4: post-filter PhysX pairs on the GPU                         */
 /* ================================================================== */
 __global__ void kernel_postfilter_pairs(
     int                          npairs,
@@ -331,7 +334,7 @@ __global__ void kernel_postfilter_pairs(
     const my_real_gpu* __restrict__ gap_m,
     const my_real_gpu* __restrict__ curv_max,
     int                          flagremnode,
-    const int* __restrict__      kremnod,  /* CSR ptr [2*nrtm]: [start,end) */
+    const int* __restrict__      kremnod,
     const int* __restrict__      remnod,
     int*                         cand_n,
     int*                         cand_e,
@@ -344,65 +347,54 @@ __global__ void kernel_postfilter_pairs(
 
     int slave_idx = pair_slave[tid];
     int ne        = pair_seg[tid];
-
-    int nn = nsv[slave_idx];   /* global node ID (1-based Fortran) */
+    int nn = nsv[slave_idx];
 
     /* (a) Corner self-pair */
-    int m0 = irect[ne*4 + 0];
-    int m1 = irect[ne*4 + 1];
-    int m2 = irect[ne*4 + 2];
-    int m3 = irect[ne*4 + 3];
+    int m0 = irect[ne*4 + 0], m1 = irect[ne*4 + 1];
+    int m2 = irect[ne*4 + 2], m3 = irect[ne*4 + 3];
     if (nn == m0 || nn == m1 || nn == m2 || nn == m3) return;
 
-    /* (b) KREMNODE linear scan (no sort requirement) */
+    /* (b) KREMNODE linear scan */
     if (flagremnode == 2) {
-        int lo = kremnod[2 * ne];
-        int hi = kremnod[2 * ne + 1];
-        for (int k = lo; k < hi; k++) {
-            if (remnod[k] == nn) return;
-        }
+        int lo = kremnod[2*ne], hi = kremnod[2*ne + 1];
+        for (int k = lo; k < hi; k++) if (remnod[k] == nn) return;
     }
 
     int jg = nn - 1;
-    my_real_gpu xs = x[3*jg + 0];
-    my_real_gpu ys = x[3*jg + 1];
-    my_real_gpu zs = x[3*jg + 2];
+    my_real_gpu xs=x[3*jg], ys=x[3*jg+1], zs=x[3*jg+2];
 
-    int jm0 = m0-1, jm1 = m1-1, jm2 = m2-1, jm3 = m3-1;
+    int jm0=m0-1, jm1=m1-1, jm2=m2-1, jm3=m3-1;
     my_real_gpu xx0=x[3*jm0],xx1=x[3*jm1],xx2=x[3*jm2],xx3=x[3*jm3];
     my_real_gpu yy0=x[3*jm0+1],yy1=x[3*jm1+1],yy2=x[3*jm2+1],yy3=x[3*jm3+1];
     my_real_gpu zz0=x[3*jm0+2],zz1=x[3*jm1+2],zz2=x[3*jm2+2],zz3=x[3*jm3+2];
 
-    my_real_gpu xmine = min(min(xx0,xx1),min(xx2,xx3));
-    my_real_gpu xmaxe = max(max(xx0,xx1),max(xx2,xx3));
-    my_real_gpu ymine = min(min(yy0,yy1),min(yy2,yy3));
-    my_real_gpu ymaxe = max(max(yy0,yy1),max(yy2,yy3));
-    my_real_gpu zmine = min(min(zz0,zz1),min(zz2,zz3));
-    my_real_gpu zmaxe = max(max(zz0,zz1),max(zz2,zz3));
+    my_real_gpu xmine=min(min(xx0,xx1),min(xx2,xx3));
+    my_real_gpu xmaxe=max(max(xx0,xx1),max(xx2,xx3));
+    my_real_gpu ymine=min(min(yy0,yy1),min(yy2,yy3));
+    my_real_gpu ymaxe=max(max(yy0,yy1),max(yy2,yy3));
+    my_real_gpu zmine=min(min(zz0,zz1),min(zz2,zz3));
+    my_real_gpu zmaxe=max(max(zz0,zz1),max(zz2,zz3));
 
-    /* (c) Per-node AABB with actual gap_s (igap!=0 only) */
+    /* (c) Per-node AABB with actual gap_s */
     my_real_gpu aaa = (my_real_gpu)0;
     if (igap != 0) {
-        my_real_gpu g = min(gapmax, max(gapmin, gap_s[slave_idx] + gap_m[ne])) + dgapload;
+        my_real_gpu g = min(gapmax, max(gapmin, gap_s[slave_idx]+gap_m[ne])) + dgapload;
         aaa = marge + curv_max[ne] + max(g, drad);
-        if (xs <= xmine - aaa || xs >= xmaxe + aaa ||
-            ys <= ymine - aaa || ys >= ymaxe + aaa ||
-            zs <= zmine - aaa || zs >= zmaxe + aaa) return;
+        if (xs<=xmine-aaa || xs>=xmaxe+aaa ||
+            ys<=ymine-aaa || ys>=ymaxe+aaa ||
+            zs<=zmine-aaa || zs>=zmaxe+aaa) return;
     }
 
     /* (d) Plane-distance underestimation */
-    my_real_gpu sx = (yy2-yy0)*(zz3-zz1) - (zz2-zz0)*(yy3-yy1);
-    my_real_gpu sy = (zz2-zz0)*(xx3-xx1) - (xx2-xx0)*(zz3-zz1);
-    my_real_gpu sz = (xx2-xx0)*(yy3-yy1) - (yy2-yy0)*(xx3-xx1);
-    my_real_gpu s2 = sx*sx + sy*sy + sz*sz;
-    my_real_gpu d1x=xs-xx0, d1y=ys-yy0, d1z=zs-zz0;
-    my_real_gpu d2x=xs-xx1, d2y=ys-yy1, d2z=zs-zz1;
-    my_real_gpu dd1=d1x*sx+d1y*sy+d1z*sz;
-    my_real_gpu dd2=d2x*sx+d2y*sy+d2z*sz;
+    my_real_gpu sx=(yy2-yy0)*(zz3-zz1)-(zz2-zz0)*(yy3-yy1);
+    my_real_gpu sy=(zz2-zz0)*(xx3-xx1)-(xx2-xx0)*(zz3-zz1);
+    my_real_gpu sz=(xx2-xx0)*(yy3-yy1)-(yy2-yy0)*(xx3-xx1);
+    my_real_gpu s2=sx*sx+sy*sy+sz*sz;
+    my_real_gpu dd1=(xs-xx0)*sx+(ys-yy0)*sy+(zs-zz0)*sz;
+    my_real_gpu dd2=(xs-xx1)*sx+(ys-yy1)*sy+(zs-zz1)*sz;
     if (dd1*dd2 > (my_real_gpu)0) {
         my_real_gpu d2 = min(dd1*dd1, dd2*dd2);
-        my_real_gpu a2 = aaa*aaa*s2;
-        if (d2 > a2) return;
+        if (d2 > aaa*aaa*s2) return;
     }
 
     int slot = atomicAdd(g_counter, 1);
@@ -431,7 +423,6 @@ int inter7_gpu_broadphase_init_(void)
                                                PxGetProfilerCallback());
     if (!g_cudaCtxMgr || !g_cudaCtxMgr->contextIsValid()) {
         fprintf(stderr, "[GPU BPH] CUDA context init failed.\n");
-        /* Release everything allocated so far before returning */
         if (g_cudaCtxMgr) { g_cudaCtxMgr->release(); g_cudaCtxMgr = nullptr; }
         g_foundation->release(); g_foundation = nullptr;
         return 1;
@@ -447,9 +438,18 @@ int inter7_gpu_broadphase_init_(void)
         return 1;
     }
 
+    g_aabbMgr = PxCreateAABBManager(*g_broadPhase);
+    if (!g_aabbMgr) {
+        fprintf(stderr, "[GPU BPH] PxCreateAABBManager failed.\n");
+        g_broadPhase->release(); g_broadPhase = nullptr;
+        g_cudaCtxMgr->release(); g_cudaCtxMgr = nullptr;
+        g_foundation->release(); g_foundation = nullptr;
+        return 1;
+    }
+
     CUDA_CHECK(cudaMalloc(&d_counter, sizeof(int)));
     g_initialised = true;
-    fprintf(stderr, "[GPU BPH] PhysX eGPU broad phase ready.\n");
+    fprintf(stderr, "[GPU BPH] PhysX eGPU broad phase ready (PxAABBManager).\n");
     return 0;
 }
 
@@ -457,9 +457,10 @@ void inter7_gpu_broadphase_destroy_(void)
 {
     if (!g_initialised) return;
 
-    if (g_broadPhase) { g_broadPhase->release(); g_broadPhase = nullptr; }
-    if (g_cudaCtxMgr) { g_cudaCtxMgr->release(); g_cudaCtxMgr = nullptr; }
-    if (g_foundation)  { g_foundation->release(); g_foundation  = nullptr; }
+    if (g_aabbMgr)   { g_aabbMgr->release();   g_aabbMgr   = nullptr; }
+    if (g_broadPhase){ g_broadPhase->release(); g_broadPhase= nullptr; }
+    if (g_cudaCtxMgr){ g_cudaCtxMgr->release(); g_cudaCtxMgr= nullptr; }
+    if (g_foundation) { g_foundation->release(); g_foundation= nullptr; }
 
     auto cfree = [](void* p){ if(p) cudaFree(p); };
     cfree(d_x);      cfree(d_nsv);      cfree(d_stfn);     cfree(d_gap_s);
@@ -468,12 +469,11 @@ void inter7_gpu_broadphase_destroy_(void)
     cfree(d_counter);
     cfree(d_slave_aabbs); cfree(d_segment_aabbs);
     cfree(d_slave_active); cfree(d_seg_active);
-    cfree(d_pair_slave);  cfree(d_pair_seg);
+    cfree(d_pair_slave);   cfree(d_pair_seg);
 
     free(h_slave_aabbs);   free(h_segment_aabbs);
     free(h_slave_active);  free(h_seg_active);
-    free(h_bounds);        free(h_groups);
-    free(h_created);       free(h_removed);
+    free(h_added_handles); free(h_decode);
     free(h_pair_slave);    free(h_pair_seg);
 
     g_initialised = false;
@@ -481,9 +481,6 @@ void inter7_gpu_broadphase_destroy_(void)
 
 int inter7_gpu_available_(void) { return g_initialised ? 1 : 0; }
 
-/* ------------------------------------------------------------------ */
-/* fill_voxel stub: not used in the PhysX path                        */
-/* ------------------------------------------------------------------ */
 void inter7_gpu_fill_voxel_(
     const int* nsn, const int* nsnr,
     const int* nbx, const int* nby, const int* nbz,
@@ -503,7 +500,7 @@ void inter7_gpu_candidate_pairs_(
     const int*         nsv,
     const int*         irect,
     const my_real_gpu* x,
-    const my_real_gpu* stfn,      /* slave node stiffness [nsn] */
+    const my_real_gpu* stfn,
     const my_real_gpu* stf,
     const my_real_gpu* xyzm,
     const int*         voxel,
@@ -542,9 +539,7 @@ void inter7_gpu_candidate_pairs_(
 
     if (h_nsn == 0 || h_nrtm == 0) { *ii_stok = 0; return; }
 
-    /* ---- upload geometry to device ----
-     * Each pointer uses its OWN size tracker so that ensure_device_* always
-     * allocates correctly even when multiple buffers have the same element count. */
+    /* ---- upload geometry to device ---- */
     ensure_device_real(&d_x,        &g_sz_x,        3 * h_numnod);
     ensure_device_int (&d_nsv,      &g_sz_nsv,      h_nsn);
     ensure_device_real(&d_stfn,     &g_sz_stfn,     h_nsn);
@@ -571,7 +566,7 @@ void inter7_gpu_candidate_pairs_(
     if (*s_remnod > 0)
         CUDA_CHECK(cudaMemcpy(d_remnod,  remnod,  (*s_remnod) *sizeof(int), cudaMemcpyHostToDevice));
 
-    /* ---- Step 1: slave point AABBs ---- */
+    /* ---- Step 1 & 2: build AABBs on GPU ---- */
     ensure_device_aabb(&d_slave_aabbs,  &g_sz_slave_aabbs, h_nsn);
     ensure_device_int (&d_slave_active, &g_sz_slave_act,   h_nsn);
     {
@@ -581,7 +576,6 @@ void inter7_gpu_candidate_pairs_(
         CUDA_CHECK(cudaGetLastError());
     }
 
-    /* ---- Step 2: segment inflated AABBs ---- */
     ensure_device_aabb(&d_segment_aabbs, &g_sz_seg_aabbs, h_nrtm);
     ensure_device_int (&d_seg_active,    &g_sz_seg_act,   h_nrtm);
     {
@@ -594,131 +588,109 @@ void inter7_gpu_candidate_pairs_(
     }
     CUDA_CHECK(cudaDeviceSynchronize());
 
-    /* ---- Download AABB data to host for PhysX submission ---- */
+    /* ---- Download to host ---- */
     ensure_host_raw((void**)&h_slave_aabbs,   &h_sz_sa_bytes,    h_nsn  *sizeof(AabbEntry));
     ensure_host_raw((void**)&h_segment_aabbs, &h_sz_seg_bytes,   h_nrtm *sizeof(AabbEntry));
     ensure_host_raw((void**)&h_slave_active,  &h_sz_sact_bytes,  h_nsn  *sizeof(int));
     ensure_host_raw((void**)&h_seg_active,    &h_sz_seact_bytes, h_nrtm *sizeof(int));
-
     CUDA_CHECK(cudaMemcpy(h_slave_aabbs,   d_slave_aabbs,   h_nsn *sizeof(AabbEntry), cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaMemcpy(h_segment_aabbs, d_segment_aabbs, h_nrtm*sizeof(AabbEntry), cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaMemcpy(h_slave_active,  d_slave_active,  h_nsn *sizeof(int),       cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaMemcpy(h_seg_active,    d_seg_active,    h_nrtm*sizeof(int),       cudaMemcpyDeviceToHost));
 
-    /* ---- Step 3: submit to PhysX GPU broad phase ----
+    /* ---- Step 3: submit objects to PxAABBManager ----
      *
-     * PxBroadPhaseUpdateData uses HANDLE-INDEXED arrays:
-     *   mBounds[handle] and mGroups[handle] are accessed for each handle
-     *   listed in mCreated[].
+     * Invariant on entry: manager is empty (all objects were removed at the
+     * end of the previous call and flushed by the cleanup update() there).
      *
-     * Handle assignment:
-     *   slave i    → handle = i          (0 .. nsn-1)
-     *   segment ne → handle = nsn + ne   (nsn .. nsn+nrtm-1)
+     * We register every active object via addObject(bounds, filterGroup).
+     * The returned handle is stored in h_added_handles[] and the decode
+     * table h_decode[handle] is populated for pair resolution.
      *
-     * Capacity = nsn + nrtm (one past the last handle).
+     * Decode encoding:
+     *   h_decode[h] = (slave_local_idx + 1)   for slaves
+     *   h_decode[h] = -(seg_local_idx + 1)    for segments
+     *   h_decode[h] = 0                        unused
+     *
+     * With a fresh, empty manager the internal handle pool starts at 0, so
+     * all handles will be in [0, total_active).  We size the table to
+     * nsn + nrtm as an upper bound and skip any pair whose handles fall
+     * outside that range (which would indicate an unexpected internal state).
      */
     int total_objs = h_nsn + h_nrtm;
-
-    ensure_host_raw((void**)&h_bounds,  &h_sz_bnd_bytes, total_objs * (int)sizeof(AabbEntry));
-    ensure_host_raw((void**)&h_groups,  &h_sz_grp_bytes, total_objs * (int)sizeof(PxU32));
-    ensure_host_raw((void**)&h_created, &h_sz_cr_bytes,  total_objs * (int)sizeof(PxU32));
-
-    PxU32 n_created = 0;
+    ensure_host_raw((void**)&h_added_handles, &h_sz_ah_bytes,  total_objs * (int)sizeof(PxU32));
+    ensure_host_raw((void**)&h_decode,        &h_sz_dec_bytes, total_objs * (int)sizeof(int));
+    memset(h_decode, 0, (size_t)total_objs * sizeof(int));
+    h_n_added = 0;
 
     for (int i = 0; i < h_nsn; i++) {
         if (!h_slave_active[i]) continue;
-        PxU32 handle = (PxU32)i;
-        h_bounds[handle] = h_slave_aabbs[i];
-        h_groups[handle] = FILTER_SLAVE;
-        h_created[n_created++] = handle;
+        PxBounds3 b(
+            PxVec3(h_slave_aabbs[i].lo[0], h_slave_aabbs[i].lo[1], h_slave_aabbs[i].lo[2]),
+            PxVec3(h_slave_aabbs[i].hi[0], h_slave_aabbs[i].hi[1], h_slave_aabbs[i].hi[2]));
+        PxU32 h = g_aabbMgr->addObject(b, FILTER_SLAVE);
+        h_added_handles[h_n_added++] = h;
+        if ((int)h < total_objs) h_decode[h] = i + 1;   /* positive → slave */
     }
     for (int ne = 0; ne < h_nrtm; ne++) {
         if (!h_seg_active[ne]) continue;
-        PxU32 handle = (PxU32)(h_nsn + ne);
-        h_bounds[handle] = h_segment_aabbs[ne];
-        h_groups[handle] = FILTER_MASTER;
-        h_created[n_created++] = handle;
+        PxBounds3 b(
+            PxVec3(h_segment_aabbs[ne].lo[0], h_segment_aabbs[ne].lo[1], h_segment_aabbs[ne].lo[2]),
+            PxVec3(h_segment_aabbs[ne].hi[0], h_segment_aabbs[ne].hi[1], h_segment_aabbs[ne].hi[2]));
+        PxU32 h = g_aabbMgr->addObject(b, FILTER_MASTER);
+        h_added_handles[h_n_added++] = h;
+        if ((int)h < total_objs) h_decode[h] = -(ne + 1);  /* negative → segment */
     }
 
-    if (n_created == 0) { *ii_stok = 0; return; }
+    if (h_n_added == 0) { *ii_stok = 0; return; }
 
-    /* PhysX 5.x PxBroadPhaseUpdateData constructor:
-     *   (created, nbCreated, updated, nbUpdated, removed, nbRemoved,
-     *    bounds, groups, distances=NULL, capacity)
-     * mBounds cast from AabbEntry* because AabbEntry == PxBounds3 layout. */
-    PxBroadPhaseUpdateData addData(
-        h_created, n_created,
-        nullptr,   0,
-        nullptr,   0,
-        reinterpret_cast<const PxBounds3*>(h_bounds),
-        h_groups,
-        nullptr,
-        (PxU32)total_objs
-    );
-    g_broadPhase->update(addData);
-
+    /* ---- Run GPU Sort-and-Prune ---- */
+    g_aabbMgr->update();          /* triggers the GPU SAP internally */
     PxBroadPhaseResults results;
-    g_broadPhase->fetchResults(results);
+    g_aabbMgr->fetchResults(results);
 
     PxU32 npairs = results.mNbCreatedPairs;
 
-    /* Prepare cleanup update data (used whether or not there are pairs) */
-    ensure_host_raw((void**)&h_removed, &h_sz_rm_bytes, (int)n_created * (int)sizeof(PxU32));
-    memcpy(h_removed, h_created, n_created * sizeof(PxU32));
-    PxBroadPhaseUpdateData removeData(
-        nullptr,   0,
-        nullptr,   0,
-        h_removed, n_created,
-        reinterpret_cast<const PxBounds3*>(h_bounds),
-        h_groups,
-        nullptr,
-        (PxU32)total_objs
-    );
-
-    if (npairs == 0) {
-        *ii_stok = 0;
-        g_broadPhase->update(removeData);
-        PxBroadPhaseResults dummy; g_broadPhase->fetchResults(dummy);
-        return;
-    }
-
-    /* ---- Unpack PhysX pairs ---- */
-    ensure_host_raw((void**)&h_pair_slave, &h_sz_ps_bytes, (int)npairs * (int)sizeof(int));
-    ensure_host_raw((void**)&h_pair_seg,   &h_sz_pe_bytes, (int)npairs * (int)sizeof(int));
-
+    /* ---- Decode pairs on CPU ---- */
     PxU32 valid = 0;
-    for (PxU32 k = 0; k < npairs; k++) {
-        PxU32 h0 = results.mCreatedPairs[k].mID0;
-        PxU32 h1 = results.mCreatedPairs[k].mID1;
-        PxU32 slave_handle, seg_handle;
-        if (h0 < (PxU32)h_nsn) { slave_handle = h0; seg_handle = h1; }
-        else                    { slave_handle = h1; seg_handle = h0; }
-        if (seg_handle < (PxU32)h_nsn ||
-            seg_handle >= (PxU32)(h_nsn + h_nrtm)) continue;
-        h_pair_slave[valid] = (int)slave_handle;
-        h_pair_seg[valid]   = (int)(seg_handle - h_nsn);
-        valid++;
+    if (npairs > 0) {
+        ensure_host_raw((void**)&h_pair_slave, &h_sz_ps_bytes, (int)npairs*(int)sizeof(int));
+        ensure_host_raw((void**)&h_pair_seg,   &h_sz_pe_bytes, (int)npairs*(int)sizeof(int));
+
+        for (PxU32 k = 0; k < npairs; k++) {
+            PxU32 ha = results.mCreatedPairs[k].mID0;
+            PxU32 hb = results.mCreatedPairs[k].mID1;
+            if ((int)ha >= total_objs || (int)hb >= total_objs) continue;
+            int da = h_decode[ha], db = h_decode[hb];
+            int slave_idx, seg_idx;
+            if      (da > 0 && db < 0) { slave_idx = da-1; seg_idx = -db-1; }
+            else if (da < 0 && db > 0) { slave_idx = db-1; seg_idx = -da-1; }
+            else continue;
+            h_pair_slave[valid] = slave_idx;
+            h_pair_seg[valid]   = seg_idx;
+            valid++;
+        }
     }
 
-    /* Remove objects before the post-filter so the GPU SAP is clean
-     * regardless of whether post-filter finds any valid pairs. */
-    g_broadPhase->update(removeData);
-    PxBroadPhaseResults dummy; g_broadPhase->fetchResults(dummy);
+    /* ---- Remove all objects; flush via update so manager is empty again ---- */
+    for (int k = 0; k < h_n_added; k++)
+        g_aabbMgr->removeObject(h_added_handles[k]);
+    g_aabbMgr->update();
+    PxBroadPhaseResults dummy; g_aabbMgr->fetchResults(dummy);
 
     if (valid == 0) { *ii_stok = 0; return; }
 
+    /* ---- Step 4: post-filter pairs on GPU ---- */
     ensure_device_int(&d_pair_slave, &g_sz_pair_slave, (int)valid);
     ensure_device_int(&d_pair_seg,   &g_sz_pair_seg,   (int)valid);
     CUDA_CHECK(cudaMemcpy(d_pair_slave, h_pair_slave, valid*sizeof(int), cudaMemcpyHostToDevice));
     CUDA_CHECK(cudaMemcpy(d_pair_seg,   h_pair_seg,   valid*sizeof(int), cudaMemcpyHostToDevice));
     CUDA_CHECK(cudaMemset(d_counter, 0, sizeof(int)));
 
-    /* ---- Step 4: post-filter on GPU ---- */
     {
         int threads = 256, blocks = ((int)valid + threads - 1) / threads;
         kernel_postfilter_pairs<<<blocks, threads>>>(
-            (int)valid,
-            d_pair_slave, d_pair_seg,
+            (int)valid, d_pair_slave, d_pair_seg,
             h_nrtm, d_irect, d_x, d_nsv,
             *igap, *marge, *gapmin, *gapmax, *dgapload, *drad,
             d_gap_s, d_gap_m, d_curv_max,
@@ -730,7 +702,6 @@ void inter7_gpu_candidate_pairs_(
 
     int h_count = 0;
     CUDA_CHECK(cudaMemcpy(&h_count, d_counter, sizeof(int), cudaMemcpyDeviceToHost));
-    /* Use std::min – host code cannot use CUDA device intrinsic min() */
     h_count = std::min(h_count, h_mulnsn);
     if (h_count > 0) {
         CUDA_CHECK(cudaMemcpy(cand_n, d_cand_n, h_count*sizeof(int), cudaMemcpyDeviceToHost));

--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase.cu
@@ -1,0 +1,768 @@
+/*Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+Copyright>
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
+
+/*
+ * inter7_gpu_broadphase.cu
+ *
+ * GPU broad-phase collision detection for Interface Type 7.
+ * See inter7_gpu_broadphase.h for the full design rationale.
+ *
+ * Algorithm (mirrors inter7_candidate_pairs.F90 / fill_voxel.F90)
+ * ================================================================
+ *
+ * fill_voxel GPU path (inter7_gpu_fill_voxel_)
+ * --------------------------------------------
+ *   Parallel over slave nodes:
+ *     1. Compute flat voxel cell index from node coordinate.
+ *     2. Use atomicCAS-based linked-list insertion to build the same
+ *        voxel[]/next_nod[] structure as the CPU path.
+ *   Output: device copies of voxel[] and next_nod[] that mirror the CPU
+ *   arrays exactly, allowing hybrid CPU/GPU operation if needed.
+ *
+ * candidate_pairs GPU path (inter7_gpu_candidate_pairs_)
+ * -------------------------------------------------------
+ *   One CUDA block per master segment (ne = 0..nrtm-1):
+ *     1. Thread 0 loads segment corners, computes inflated AABB, surface
+ *        normal (sx,sy,sz), and voxel range (ix1..ix2, iy1..iy2, iz1..iz2)
+ *        into shared memory.
+ *     2. Threads cooperatively sweep the voxel range; each thread handles
+ *        a subset of the IX dimension.
+ *     3. For each node found in a voxel cell the following rejection
+ *        filters are applied (early exit on first rejection):
+ *          (a) Corner self-pair: node global ID == M1/M2/M3/M4 → skip.
+ *          (b) KREMNODE forbidden pair: binary search in the per-segment
+ *              CSR list of forbidden node IDs → skip if found.
+ *          (c) Expanded AABB: node outside [xmine-aaa, xmaxe+aaa] → skip.
+ *          (d) Plane-distance underestimation: same formula as CPU → skip.
+ *     4. Valid pairs are accumulated in shared memory and flushed to global
+ *        device output using a single atomicAdd per block flush.
+ *
+ * PhysX integration
+ * -----------------
+ *   PxCudaContextManager is used for device context ownership and stream
+ *   management.  This keeps CUDA contexts consistent when the calling
+ *   simulation also uses PhysX (rigid-body simulation, cloth, etc.).
+ *   If PhysX is not available the implementation falls back to raw CUDA.
+ */
+
+#include "inter7_gpu_broadphase.h"
+
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* ------------------------------------------------------------------ */
+/* Optional PhysX CUDA context manager                                 */
+/* ------------------------------------------------------------------ */
+#ifdef USE_PHYSX
+  #include <PxPhysicsAPI.h>
+  using namespace physx;
+  static PxFoundation*          g_foundation    = nullptr;
+  static PxCudaContextManager*  g_cudaCtxMgr    = nullptr;
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Compile-time block size for the candidate kernel                    */
+/* ------------------------------------------------------------------ */
+#define BLOCK_SIZE  128
+/* Maximum candidate pairs buffered in shared memory per block before  */
+/* flushing to the global output (must be >= BLOCK_SIZE)              */
+#define BLOCK_BUF   256
+
+/* ------------------------------------------------------------------ */
+/* Global device state                                                 */
+/* ------------------------------------------------------------------ */
+static int   g_device_id   = -1;   /* -1 = not initialised             */
+static bool  g_initialised = false;
+
+/* Device persistent buffers (reallocated as needed) */
+static int*        d_voxel     = nullptr;
+static int*        d_next_nod  = nullptr;
+static int*        d_nsv       = nullptr;
+static int*        d_irect     = nullptr;
+static int*        d_cand_n    = nullptr;
+static int*        d_cand_e    = nullptr;
+static int*        d_counter   = nullptr;   /* atomic output counter */
+static int*        d_kremnod   = nullptr;
+static int*        d_remnod    = nullptr;
+
+static my_real_gpu* d_x        = nullptr;
+static my_real_gpu* d_stf      = nullptr;
+static my_real_gpu* d_gap_s    = nullptr;
+static my_real_gpu* d_gap_m    = nullptr;
+static my_real_gpu* d_curv_max = nullptr;
+
+/* Sizes of current device allocations */
+static int g_sz_voxel   = 0;
+static int g_sz_nod     = 0;   /* nsn + nsnr */
+static int g_sz_numnod  = 0;
+static int g_sz_nrtm    = 0;
+static int g_sz_cand    = 0;
+static int g_sz_kremnod = 0;
+static int g_sz_remnod  = 0;
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+#define CUDA_CHECK(call)                                                    \
+  do {                                                                      \
+    cudaError_t err = (call);                                               \
+    if (err != cudaSuccess) {                                               \
+      fprintf(stderr, "[GPU BPH] CUDA error %s at %s:%d\n",               \
+              cudaGetErrorString(err), __FILE__, __LINE__);                 \
+    }                                                                       \
+  } while(0)
+
+/* Reallocate device buffer if size has grown */
+static void ensure_device_int(int** ptr, int* cur_sz, int needed)
+{
+    if (needed > *cur_sz) {
+        if (*ptr) cudaFree(*ptr);
+        CUDA_CHECK(cudaMalloc(ptr, (size_t)needed * sizeof(int)));
+        *cur_sz = needed;
+    }
+}
+static void ensure_device_real(my_real_gpu** ptr, int* cur_sz, int needed)
+{
+    if (needed > *cur_sz) {
+        if (*ptr) cudaFree(*ptr);
+        CUDA_CHECK(cudaMalloc(ptr, (size_t)needed * sizeof(my_real_gpu)));
+        *cur_sz = needed;
+    }
+}
+
+/* ================================================================== */
+/* fill_voxel kernel                                                   */
+/* Each thread processes one slave node and inserts it into the voxel  */
+/* linked list using atomicExch-based compare-and-swap chaining.       */
+/* ================================================================== */
+__global__ void kernel_fill_voxel(
+    int                    nsn,
+    const int* __restrict__ nsv,       /* slave-to-global map [nsn]          */
+    const my_real_gpu* __restrict__ x, /* node coords [3*numnod], col-major  */
+    const my_real_gpu* __restrict__ stfn,
+    my_real_gpu xmin, my_real_gpu ymin, my_real_gpu zmin,
+    my_real_gpu xmax, my_real_gpu ymax, my_real_gpu zmax,
+    my_real_gpu xminb, my_real_gpu yminb, my_real_gpu zminb,
+    my_real_gpu xmaxb, my_real_gpu ymaxb, my_real_gpu zmaxb,
+    int nbx, int nby, int nbz,
+    int* __restrict__ voxel,           /* voxel head [(nbx+2)*(nby+2)*(nbz+2)] */
+    int* __restrict__ next_nod         /* next-node chain [nsn]                */
+)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= nsn) return;
+
+    /* Fortran 1-based index i+1 → local index i (0-based in C) */
+    if (stfn[i] == (my_real_gpu)0) {
+        next_nod[i] = 0;
+        return;
+    }
+
+    /* Fortran: j = NSV(i+1),  x(1,j) stored at x[3*(j-1)+0] */
+    int j = nsv[i] - 1;   /* 0-based global node index */
+    my_real_gpu xj = x[3*j + 0];
+    my_real_gpu yj = x[3*j + 1];
+    my_real_gpu zj = x[3*j + 2];
+
+    if (xj < xmin || xj > xmax || yj < ymin || yj > ymax || zj < zmin || zj > zmax) {
+        next_nod[i] = 0;
+        return;
+    }
+
+    int ix = (int)(nbx * (xj - xminb) / (xmaxb - xminb));
+    int iy = (int)(nby * (yj - yminb) / (ymaxb - yminb));
+    int iz = (int)(nbz * (zj - zminb) / (zmaxb - zminb));
+
+    /* Fortran: MAX(1, 2+MIN(NBX, ix)) – map to [1, NBX+2] in Fortran */
+    if (ix < 0)   ix = -1; /* will become 1 after +2 clamp */
+    if (ix > nbx) ix = nbx;
+    ix = 1 + ix;   /* shift so range is [1, nbx+1]; then clamp below  */
+    /* replicate Fortran: MAX(1, 2+MIN(NBX,ix_raw)) */
+    /* We have ix_raw in [0,nbx].  2+MIN(NBX,ix_raw) in [2,nbx+2].   */
+    /* MAX(1, ...) is always 2+ for in-range nodes → range [2,nbx+2]. */
+    /* Re-compute cleanly: */
+    int ix_raw = (int)(nbx * (xj - xminb) / (xmaxb - xminb));
+    int iy_raw = (int)(nby * (yj - yminb) / (ymaxb - yminb));
+    int iz_raw = (int)(nbz * (zj - zminb) / (zmaxb - zminb));
+    ix = max(1, 2 + min(nbx, ix_raw));
+    iy = max(1, 2 + min(nby, iy_raw));
+    iz = max(1, 2 + min(nbz, iz_raw));
+
+    /* Flat cell index (1-based in Fortran, 0-based C equivalent) */
+    int cellid = (iz - 1) * (nbx + 2) * (nby + 2) + (iy - 1) * (nbx + 2) + ix - 1;
+
+    /*
+     * Atomic linked-list insertion.
+     * voxel[cellid] holds the index (1-based, Fortran convention) of the
+     * first node in the cell, or 0 if empty.
+     * We insert node i+1 (Fortran 1-based) at the head atomically.
+     */
+    int old_head = atomicExch(&voxel[cellid], i + 1);  /* +1: Fortran 1-based */
+    next_nod[i] = old_head;  /* chain the old head as our successor */
+}
+
+/* ================================================================== */
+/* Binary search helper (device)                                       */
+/* Returns true if key is found in sorted array a[lo..hi).            */
+/* ================================================================== */
+__device__ __forceinline__ bool dev_binary_search(
+    const int* __restrict__ a, int lo, int hi, int key)
+{
+    while (lo < hi) {
+        int mid = lo + ((hi - lo) >> 1);
+        if      (a[mid] == key) return true;
+        else if (a[mid] <  key) lo = mid + 1;
+        else                    hi = mid;
+    }
+    return false;
+}
+
+/* ================================================================== */
+/* Candidate pairs kernel                                              */
+/* One block per master segment.  Threads cooperate over the voxel     */
+/* range of the segment's inflated AABB.                               */
+/* ================================================================== */
+__global__ void kernel_candidate_pairs(
+    /* geometry */
+    int                     nrtm,
+    int                     nsn,
+    const int* __restrict__ irect,         /* [4 * nrtm], col-major: irect[ne + k*nrtm] */
+    const my_real_gpu* __restrict__ x,     /* [3 * numnod], col-major */
+    const int* __restrict__ nsv,           /* [nsn]                   */
+    const int* __restrict__ voxel,         /* [(nbx+2)*(nby+2)*(nbz+2)] */
+    const int* __restrict__ next_nod,      /* [nsn+nsnr]              */
+    /* bounding box */
+    my_real_gpu xminb, my_real_gpu yminb, my_real_gpu zminb,
+    my_real_gpu xmaxb, my_real_gpu ymaxb, my_real_gpu zmaxb,
+    int nbx, int nby, int nbz,
+    /* gap / contact parameters */
+    int igap,
+    my_real_gpu marge,
+    my_real_gpu tzinf,
+    my_real_gpu gap,
+    my_real_gpu gapmin, my_real_gpu gapmax, my_real_gpu bgapsmx,
+    my_real_gpu drad,   my_real_gpu dgapload,
+    const my_real_gpu* __restrict__ gap_s,
+    const my_real_gpu* __restrict__ gap_m,
+    const my_real_gpu* __restrict__ curv_max,
+    const my_real_gpu* __restrict__ stf,
+    /* kremnode rejection (CSR format) */
+    int flagremnode,
+    const int* __restrict__ kremnod,   /* [s_kremnod] – see below */
+    const int* __restrict__ remnod,    /* [s_remnod]              */
+    /*
+     * KREMNODE CSR layout (0-based C, Fortran 1-based in the original):
+     *   for segment ne (0-based):
+     *     local forbidden: remnod[ kremnod[2*ne] .. kremnod[2*ne+1]-1 ]
+     *   (sorted ascending per segment)
+     */
+    /* output */
+    int*  cand_n,      /* [mulnsn] */
+    int*  cand_e,      /* [mulnsn] */
+    int*  g_counter,   /* global atomic counter */
+    int   mulnsn       /* max candidates        */
+)
+{
+    /* Each block handles one segment */
+    int ne = blockIdx.x;
+    if (ne >= nrtm) return;
+
+    /* ---------------------------------------------------------------- */
+    /* Shared memory                                                     */
+    /* ---------------------------------------------------------------- */
+    __shared__ my_real_gpu s_xx[4], s_yy[4], s_zz[4]; /* corner coords  */
+    __shared__ my_real_gpu s_sx, s_sy, s_sz, s_s2;    /* surface normal */
+    __shared__ my_real_gpu s_xmine, s_ymine, s_zmine;
+    __shared__ my_real_gpu s_xmaxe, s_ymaxe, s_zmaxe;
+    __shared__ my_real_gpu s_aaa;                      /* influence zone  */
+    __shared__ int         s_m[4];                    /* corner node IDs */
+    __shared__ int         s_ix1, s_iy1, s_iz1;
+    __shared__ int         s_ix2, s_iy2, s_iz2;
+    __shared__ int         s_krem_lo, s_krem_hi;      /* kremnode range  */
+    __shared__ int         s_valid;                   /* segment alive?  */
+
+    /* Block-level candidate buffer before global flush */
+    __shared__ int  s_buf_n[BLOCK_BUF];
+    __shared__ int  s_buf_e[BLOCK_BUF];
+    __shared__ int  s_buf_cnt;
+
+    if (threadIdx.x == 0) {
+        s_buf_cnt = 0;
+        s_valid   = (stf[ne] != (my_real_gpu)0) ? 1 : 0;
+
+        if (s_valid) {
+            /* Fortran irect(k,ne+1) → C irect[ne + (k-1)*nrtm] (col-major) */
+            s_m[0] = irect[ne + 0 * nrtm];   /* M1 */
+            s_m[1] = irect[ne + 1 * nrtm];   /* M2 */
+            s_m[2] = irect[ne + 2 * nrtm];   /* M3 */
+            s_m[3] = irect[ne + 3 * nrtm];   /* M4 */
+
+            /* Node coords (Fortran: x(k,j) → C: x[3*(j-1)+(k-1)]) */
+            #define XC(j,k) x[3*((j)-1)+(k)]
+            s_xx[0] = XC(s_m[0], 0); s_yy[0] = XC(s_m[0], 1); s_zz[0] = XC(s_m[0], 2);
+            s_xx[1] = XC(s_m[1], 0); s_yy[1] = XC(s_m[1], 1); s_zz[1] = XC(s_m[1], 2);
+            s_xx[2] = XC(s_m[2], 0); s_yy[2] = XC(s_m[2], 1); s_zz[2] = XC(s_m[2], 2);
+            s_xx[3] = XC(s_m[3], 0); s_yy[3] = XC(s_m[3], 1); s_zz[3] = XC(s_m[3], 2);
+            #undef XC
+
+            s_xmaxe = max(max(s_xx[0], s_xx[1]), max(s_xx[2], s_xx[3]));
+            s_xmine = min(min(s_xx[0], s_xx[1]), min(s_xx[2], s_xx[3]));
+            s_ymaxe = max(max(s_yy[0], s_yy[1]), max(s_yy[2], s_yy[3]));
+            s_ymine = min(min(s_yy[0], s_yy[1]), min(s_yy[2], s_yy[3]));
+            s_zmaxe = max(max(s_zz[0], s_zz[1]), max(s_zz[2], s_zz[3]));
+            s_zmine = min(min(s_zz[0], s_zz[1]), min(s_zz[2], s_zz[3]));
+
+            /* Surface normal (cross product of diagonals, same as CPU) */
+            s_sx = (s_yy[2]-s_yy[0])*(s_zz[3]-s_zz[1]) - (s_zz[2]-s_zz[0])*(s_yy[3]-s_yy[1]);
+            s_sy = (s_zz[2]-s_zz[0])*(s_xx[3]-s_xx[1]) - (s_xx[2]-s_xx[0])*(s_zz[3]-s_zz[1]);
+            s_sz = (s_xx[2]-s_xx[0])*(s_yy[3]-s_yy[1]) - (s_yy[2]-s_yy[0])*(s_xx[3]-s_xx[1]);
+            s_s2 = s_sx*s_sx + s_sy*s_sy + s_sz*s_sz;
+
+            /* Influence zone radius */
+            if (igap == 0) {
+                s_aaa = tzinf + curv_max[ne];
+            } else {
+                my_real_gpu g = min(gapmax, max(gapmin, bgapsmx + gap_m[ne])) + dgapload;
+                s_aaa = marge + curv_max[ne] + max(g, drad);
+            }
+
+            /* Voxel range for inflated AABB */
+            int ix1r, ix2r, iy1r, iy2r, iz1r, iz2r;
+            if (nbx > 1) {
+                my_real_gpu inv_dx = nbx / (xmaxb - xminb);
+                ix1r = (int)((s_xmine - s_aaa - xminb) * inv_dx);
+                ix2r = (int)((s_xmaxe + s_aaa - xminb) * inv_dx);
+            } else { ix1r = -2; ix2r = 1; }
+            if (nby > 1) {
+                my_real_gpu inv_dy = nby / (ymaxb - yminb);
+                iy1r = (int)((s_ymine - s_aaa - yminb) * inv_dy);
+                iy2r = (int)((s_ymaxe + s_aaa - yminb) * inv_dy);
+            } else { iy1r = -2; iy2r = 1; }
+            if (nbz > 1) {
+                my_real_gpu inv_dz = nbz / (zmaxb - zminb);
+                iz1r = (int)((s_zmine - s_aaa - zminb) * inv_dz);
+                iz2r = (int)((s_zmaxe + s_aaa - zminb) * inv_dz);
+            } else { iz1r = -2; iz2r = 1; }
+
+            s_ix1 = max(1, 2 + min(nbx, ix1r));
+            s_iy1 = max(1, 2 + min(nby, iy1r));
+            s_iz1 = max(1, 2 + min(nbz, iz1r));
+            s_ix2 = max(1, 2 + min(nbx, ix2r));
+            s_iy2 = max(1, 2 + min(nby, iy2r));
+            s_iz2 = max(1, 2 + min(nbz, iz2r));
+
+            /* KREMNODE range for this segment (CSR 0-based) */
+            if (flagremnode == 2) {
+                s_krem_lo = kremnod[2 * ne];
+                s_krem_hi = kremnod[2 * ne + 1];
+            } else {
+                s_krem_lo = 0;
+                s_krem_hi = 0;
+            }
+        }
+    }
+    __syncthreads();
+
+    if (!s_valid) return;
+
+    /* ---------------------------------------------------------------- */
+    /* Sweep voxel range: distribute IX over threads in the block        */
+    /* ---------------------------------------------------------------- */
+    int ix_range = s_ix2 - s_ix1 + 1;
+    int nbx2     = nbx + 2;
+    int nbxnby   = nbx2 * (nby + 2);
+
+    for (int iz = s_iz1; iz <= s_iz2; iz++) {
+        for (int iy = s_iy1; iy <= s_iy2; iy++) {
+            /* Base cell index for (iz, iy, *) */
+            int cell_base = (iz - 1) * nbxnby + (iy - 1) * nbx2;
+
+            for (int ix_off = threadIdx.x; ix_off < ix_range; ix_off += blockDim.x) {
+                int ix = s_ix1 + ix_off;
+                int cellid = cell_base + ix - 1;   /* 0-based flat index */
+
+                /* Walk the linked list for this cell */
+                int jj = voxel[cellid];
+                while (jj > 0) {
+                    /* Only local slave nodes (jj <= nsn).
+                     * Remote SPMD nodes (jj > nsn) are handled by the CPU
+                     * path (SPMD exchange precedes this call) – skip here. */
+                    if (jj <= nsn) {
+                        int nn = nsv[jj - 1];  /* global node ID (1-based) */
+
+                        /* (a) Corner self-pair rejection */
+                        if (nn == s_m[0] || nn == s_m[1] ||
+                            nn == s_m[2] || nn == s_m[3]) {
+                            jj = next_nod[jj - 1];
+                            continue;
+                        }
+
+                        /* (b) KREMNODE forbidden pair rejection */
+                        if (flagremnode == 2 && s_krem_lo < s_krem_hi) {
+                            if (dev_binary_search(remnod, s_krem_lo, s_krem_hi, nn)) {
+                                jj = next_nod[jj - 1];
+                                continue;
+                            }
+                        }
+
+                        /* Node position */
+                        my_real_gpu xs = x[3*(nn-1) + 0];
+                        my_real_gpu ys = x[3*(nn-1) + 1];
+                        my_real_gpu zs = x[3*(nn-1) + 2];
+
+                        /* Per-node AAA when igap != 0 */
+                        my_real_gpu aaa = s_aaa;
+                        if (igap != 0) {
+                            my_real_gpu g = min(gapmax, max(gapmin,
+                                gap_s[jj-1] + gap_m[ne])) + dgapload;
+                            aaa = marge + curv_max[ne] + max(g, drad);
+                        }
+
+                        /* (c) Expanded AABB rejection */
+                        if (xs <= s_xmine - aaa || xs >= s_xmaxe + aaa ||
+                            ys <= s_ymine - aaa || ys >= s_ymaxe + aaa ||
+                            zs <= s_zmine - aaa || zs >= s_zmaxe + aaa) {
+                            jj = next_nod[jj - 1];
+                            continue;
+                        }
+
+                        /* (d) Plane-distance underestimation (same as CPU) */
+                        my_real_gpu d1x = xs - s_xx[0], d1y = ys - s_yy[0], d1z = zs - s_zz[0];
+                        my_real_gpu d2x = xs - s_xx[1], d2y = ys - s_yy[1], d2z = zs - s_zz[1];
+                        my_real_gpu dd1 = d1x*s_sx + d1y*s_sy + d1z*s_sz;
+                        my_real_gpu dd2 = d2x*s_sx + d2y*s_sy + d2z*s_sz;
+                        if (dd1 * dd2 > (my_real_gpu)0) {
+                            my_real_gpu d2  = min(dd1*dd1, dd2*dd2);
+                            my_real_gpu a2  = aaa*aaa*s_s2;
+                            if (d2 > a2) {
+                                jj = next_nod[jj - 1];
+                                continue;
+                            }
+                        }
+
+                        /* Valid candidate – store in shared buffer */
+                        int slot = atomicAdd(&s_buf_cnt, 1);
+                        if (slot < BLOCK_BUF) {
+                            s_buf_n[slot] = jj;        /* local slave index (1-based) */
+                            s_buf_e[slot] = ne + 1;    /* local segment index (1-based) */
+                        }
+                        /* If buffer is full, flush now */
+                        if (slot + 1 == BLOCK_BUF) {
+                            __syncthreads();
+                            if (threadIdx.x == 0) {
+                                int base = atomicAdd(g_counter, BLOCK_BUF);
+                                int write_n = min(BLOCK_BUF, mulnsn - base);
+                                for (int k = 0; k < write_n; k++) {
+                                    cand_n[base + k] = s_buf_n[k];
+                                    cand_e[base + k] = s_buf_e[k];
+                                }
+                                s_buf_cnt = 0;
+                            }
+                            __syncthreads();
+                        }
+                    }
+                    jj = next_nod[jj - 1];
+                }
+            }
+        }
+    }
+
+    /* Final flush of partial buffer */
+    __syncthreads();
+    if (threadIdx.x == 0 && s_buf_cnt > 0) {
+        int cnt  = s_buf_cnt;
+        int base = atomicAdd(g_counter, cnt);
+        int write_n = min(cnt, mulnsn - base);
+        if (write_n > 0) {
+            for (int k = 0; k < write_n; k++) {
+                cand_n[base + k] = s_buf_n[k];
+                cand_e[base + k] = s_buf_e[k];
+            }
+        }
+    }
+}
+
+/* ================================================================== */
+/* Public C API                                                        */
+/* ================================================================== */
+
+int inter7_gpu_broadphase_init_(void)
+{
+    if (g_initialised) return 0;
+
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count == 0) {
+        fprintf(stderr, "[GPU BPH] No CUDA-capable device found.\n");
+        return 1;
+    }
+
+    /* Pick device 0 (or the one set by CUDA_VISIBLE_DEVICES) */
+    g_device_id = 0;
+    CUDA_CHECK(cudaSetDevice(g_device_id));
+
+#ifdef USE_PHYSX
+    /* Initialise PhysX Foundation and CUDA context manager */
+    g_foundation = PxCreateFoundation(PX_PHYSICS_VERSION,
+                                      gDefaultAllocatorCallback,
+                                      gDefaultErrorCallback);
+    if (!g_foundation) {
+        fprintf(stderr, "[GPU BPH] PhysX Foundation init failed.\n");
+        return 1;
+    }
+    PxCudaContextManagerDesc cudaCtxDesc;
+    g_cudaCtxMgr = PxCreateCudaContextManager(*g_foundation, cudaCtxDesc,
+                                               PxGetProfilerCallback());
+    if (!g_cudaCtxMgr || !g_cudaCtxMgr->contextIsValid()) {
+        fprintf(stderr, "[GPU BPH] PhysX CUDA context init failed.\n");
+        return 1;
+    }
+    fprintf(stderr, "[GPU BPH] PhysX CUDA context manager ready.\n");
+#endif
+
+    /* Allocate the atomic output counter */
+    CUDA_CHECK(cudaMalloc(&d_counter, sizeof(int)));
+    CUDA_CHECK(cudaMemset(d_counter, 0, sizeof(int)));
+
+    g_initialised = true;
+    return 0;
+}
+
+void inter7_gpu_broadphase_destroy_(void)
+{
+    if (!g_initialised) return;
+
+    if (d_voxel)    { cudaFree(d_voxel);    d_voxel    = nullptr; }
+    if (d_next_nod) { cudaFree(d_next_nod); d_next_nod = nullptr; }
+    if (d_nsv)      { cudaFree(d_nsv);      d_nsv      = nullptr; }
+    if (d_irect)    { cudaFree(d_irect);    d_irect    = nullptr; }
+    if (d_cand_n)   { cudaFree(d_cand_n);   d_cand_n   = nullptr; }
+    if (d_cand_e)   { cudaFree(d_cand_e);   d_cand_e   = nullptr; }
+    if (d_counter)  { cudaFree(d_counter);  d_counter  = nullptr; }
+    if (d_kremnod)  { cudaFree(d_kremnod);  d_kremnod  = nullptr; }
+    if (d_remnod)   { cudaFree(d_remnod);   d_remnod   = nullptr; }
+    if (d_x)        { cudaFree(d_x);        d_x        = nullptr; }
+    if (d_stf)      { cudaFree(d_stf);      d_stf      = nullptr; }
+    if (d_gap_s)    { cudaFree(d_gap_s);    d_gap_s    = nullptr; }
+    if (d_gap_m)    { cudaFree(d_gap_m);    d_gap_m    = nullptr; }
+    if (d_curv_max) { cudaFree(d_curv_max); d_curv_max = nullptr; }
+
+    g_sz_voxel = g_sz_nod = g_sz_numnod = g_sz_nrtm = 0;
+    g_sz_cand  = g_sz_kremnod = g_sz_remnod = 0;
+
+#ifdef USE_PHYSX
+    if (g_cudaCtxMgr) { g_cudaCtxMgr->release(); g_cudaCtxMgr = nullptr; }
+    if (g_foundation)  { g_foundation->release();  g_foundation  = nullptr; }
+#endif
+
+    g_initialised = false;
+}
+
+int inter7_gpu_available_(void)
+{
+    return g_initialised ? 1 : 0;
+}
+
+/* ------------------------------------------------------------------ */
+void inter7_gpu_fill_voxel_(
+    const int*       nsn,
+    const int*       nsnr,
+    const int*       nbx,
+    const int*       nby,
+    const int*       nbz,
+    const int*       nrtm,
+    const int*       numnod,
+    const int*       nsv,
+    const my_real_gpu* x,
+    const my_real_gpu* stfn,
+    const my_real_gpu* box_limit  /* same layout as BMINMA in fill_voxel.F90 */
+)
+{
+    if (!g_initialised) return;
+    if (*nrtm == 0 || *nsn == 0) return;
+
+    int h_nbx = *nbx, h_nby = *nby, h_nbz = *nbz;
+    int h_nsn = *nsn, h_nsnr = *nsnr, h_numnod = *numnod;
+    int voxel_sz = (h_nbx + 2) * (h_nby + 2) * (h_nbz + 2);
+    int nod_sz   = h_nsn + h_nsnr;
+
+    /* Reallocate device buffers as needed */
+    ensure_device_int(&d_voxel,     &g_sz_voxel,  voxel_sz);
+    ensure_device_int(&d_next_nod,  &g_sz_nod,    nod_sz);
+    ensure_device_int(&d_nsv,       &g_sz_nod,    h_nsn);      /* may already be large enough */
+    ensure_device_real(&d_x,        &g_sz_numnod, 3 * h_numnod);
+
+    /* BMINMA layout: (1)=xmax,(2)=ymax,(3)=zmax,(4)=xmin,...
+     * xmin = box_limit[3], xmax = box_limit[0] (0-based C) */
+    my_real_gpu h_xmax  = box_limit[0], h_ymax  = box_limit[1], h_zmax  = box_limit[2];
+    my_real_gpu h_xmin  = box_limit[3], h_ymin  = box_limit[4], h_zmin  = box_limit[5];
+    my_real_gpu h_xmaxb = box_limit[6], h_ymaxb = box_limit[7], h_zmaxb = box_limit[8];
+    my_real_gpu h_xminb = box_limit[9], h_yminb = box_limit[10],h_zminb = box_limit[11];
+
+    /* Upload */
+    CUDA_CHECK(cudaMemset(d_voxel,   0, (size_t)voxel_sz * sizeof(int)));
+    CUDA_CHECK(cudaMemset(d_next_nod,0, (size_t)nod_sz   * sizeof(int)));
+    CUDA_CHECK(cudaMemcpy(d_nsv, nsv,  (size_t)h_nsn * sizeof(int),       cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_x,   x,    (size_t)3*h_numnod*sizeof(my_real_gpu), cudaMemcpyHostToDevice));
+
+    /* Also upload stfn (reuse d_gap_s buffer for this call) */
+    ensure_device_real(&d_gap_s, &g_sz_nrtm, h_nsn);
+    CUDA_CHECK(cudaMemcpy(d_gap_s, stfn, (size_t)h_nsn * sizeof(my_real_gpu), cudaMemcpyHostToDevice));
+
+    /* Launch kernel */
+    int threads = 256;
+    int blocks  = (h_nsn + threads - 1) / threads;
+    kernel_fill_voxel<<<blocks, threads>>>(
+        h_nsn, d_nsv, d_x, d_gap_s,
+        h_xmin, h_ymin, h_zmin, h_xmax, h_ymax, h_zmax,
+        h_xminb, h_yminb, h_zminb, h_xmaxb, h_ymaxb, h_zmaxb,
+        h_nbx, h_nby, h_nbz,
+        d_voxel, d_next_nod
+    );
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+/* ------------------------------------------------------------------ */
+void inter7_gpu_candidate_pairs_(
+    const int*       nsn,
+    const int*       nrtm,
+    const int*       numnod,
+    const int*       nsv,
+    const int*       irect,
+    const my_real_gpu* x,
+    const my_real_gpu* stf,
+    const my_real_gpu* xyzm,
+    const int*       voxel,
+    const int*       next_nod,
+    const int*       nsnr,
+    const int*       nbx,
+    const int*       nby,
+    const int*       nbz,
+    const int*       igap,
+    const my_real_gpu* marge,
+    const my_real_gpu* tzinf,
+    const my_real_gpu* gap,
+    const my_real_gpu* gapmin,
+    const my_real_gpu* gapmax,
+    const my_real_gpu* bgapsmx,
+    const my_real_gpu* drad,
+    const my_real_gpu* dgapload,
+    const my_real_gpu* gap_s,
+    const my_real_gpu* gap_m,
+    const my_real_gpu* curv_max,
+    const int*       flagremnode,
+    const int*       s_kremnod,
+    const int*       kremnod,
+    const int*       s_remnod,
+    const int*       remnod,
+    const int*       mulnsn,
+    int*             cand_n,
+    int*             cand_e,
+    int*             ii_stok
+)
+{
+    if (!g_initialised) return;
+
+    int h_nsn    = *nsn,    h_nrtm   = *nrtm;
+    int h_numnod = *numnod, h_nsnr   = *nsnr;
+    int h_nbx    = *nbx,    h_nby    = *nby,    h_nbz    = *nbz;
+    int h_mulnsn = *mulnsn;
+    int h_flagrn = *flagremnode;
+    int h_igap   = *igap;
+
+    if (h_nrtm == 0 || h_nsn == 0) { *ii_stok = 0; return; }
+
+    int voxel_sz = (h_nbx + 2) * (h_nby + 2) * (h_nbz + 2);
+    int nod_sz   = h_nsn + h_nsnr;
+
+    /* ---- Reallocate device buffers ---- */
+    ensure_device_int(&d_voxel,     &g_sz_voxel,  voxel_sz);
+    ensure_device_int(&d_next_nod,  &g_sz_nod,    nod_sz);
+    ensure_device_int(&d_nsv,       &g_sz_nod,    h_nsn);
+    ensure_device_int(&d_irect,     &g_sz_nrtm,   4 * h_nrtm);
+    ensure_device_int(&d_cand_n,    &g_sz_cand,   h_mulnsn);
+    ensure_device_int(&d_cand_e,    &g_sz_cand,   h_mulnsn);
+    ensure_device_real(&d_x,        &g_sz_numnod, 3 * h_numnod);
+    ensure_device_real(&d_stf,      &g_sz_nrtm,   h_nrtm);
+    ensure_device_real(&d_gap_s,    &g_sz_nod,    h_nsn);
+    ensure_device_real(&d_gap_m,    &g_sz_nrtm,   h_nrtm);
+    ensure_device_real(&d_curv_max, &g_sz_nrtm,   h_nrtm);
+
+    /* KREMNODE CSR */
+    int h_s_kremnod = *s_kremnod;
+    int h_s_remnod  = *s_remnod;
+    ensure_device_int(&d_kremnod, &g_sz_kremnod, max(h_s_kremnod, 1));
+    ensure_device_int(&d_remnod,  &g_sz_remnod,  max(h_s_remnod,  1));
+
+    /* ---- Upload host → device ---- */
+    CUDA_CHECK(cudaMemcpy(d_voxel,    voxel,    (size_t)voxel_sz * sizeof(int),       cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_next_nod, next_nod, (size_t)nod_sz   * sizeof(int),       cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_nsv,      nsv,      (size_t)h_nsn    * sizeof(int),       cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_irect,    irect,    (size_t)4*h_nrtm * sizeof(int),       cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_x,        x,        (size_t)3*h_numnod*sizeof(my_real_gpu),cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_stf,      stf,      (size_t)h_nrtm   * sizeof(my_real_gpu),cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_gap_s,    gap_s,    (size_t)h_nsn    * sizeof(my_real_gpu),cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_gap_m,    gap_m,    (size_t)h_nrtm   * sizeof(my_real_gpu),cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(d_curv_max, curv_max, (size_t)h_nrtm   * sizeof(my_real_gpu),cudaMemcpyHostToDevice));
+    if (h_s_kremnod > 0)
+        CUDA_CHECK(cudaMemcpy(d_kremnod, kremnod, (size_t)h_s_kremnod * sizeof(int), cudaMemcpyHostToDevice));
+    if (h_s_remnod > 0)
+        CUDA_CHECK(cudaMemcpy(d_remnod,  remnod,  (size_t)h_s_remnod  * sizeof(int), cudaMemcpyHostToDevice));
+
+    /* Reset output counter */
+    CUDA_CHECK(cudaMemset(d_counter, 0, sizeof(int)));
+
+    /*
+     * xyzm layout (Fortran inter7_candidate_pairs.F90):
+     *   xyzm(1..6)  = xmin,ymin,zmin,xmax,ymax,zmax
+     *   xyzm(7..12) = xminb,yminb,zminb,xmaxb,ymaxb,zmaxb
+     * In C (0-based): xyzm[0..5], xyzm[6..11]
+     */
+    my_real_gpu h_xminb = xyzm[6],  h_yminb = xyzm[7],  h_zminb = xyzm[8];
+    my_real_gpu h_xmaxb = xyzm[9],  h_ymaxb = xyzm[10], h_zmaxb = xyzm[11];
+
+    /* ---- Launch candidate kernel: one block per segment ---- */
+    kernel_candidate_pairs<<<h_nrtm, BLOCK_SIZE>>>(
+        h_nrtm, h_nsn,
+        d_irect, d_x, d_nsv,
+        d_voxel, d_next_nod,
+        h_xminb, h_yminb, h_zminb,
+        h_xmaxb, h_ymaxb, h_zmaxb,
+        h_nbx, h_nby, h_nbz,
+        h_igap,
+        *marge, *tzinf, *gap, *gapmin, *gapmax, *bgapsmx, *drad, *dgapload,
+        d_gap_s, d_gap_m, d_curv_max, d_stf,
+        h_flagrn, d_kremnod, d_remnod,
+        d_cand_n, d_cand_e, d_counter, h_mulnsn
+    );
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    /* ---- Read back results ---- */
+    int h_count = 0;
+    CUDA_CHECK(cudaMemcpy(&h_count, d_counter, sizeof(int), cudaMemcpyDeviceToHost));
+    h_count = min(h_count, h_mulnsn);
+
+    if (h_count > 0) {
+        CUDA_CHECK(cudaMemcpy(cand_n, d_cand_n, (size_t)h_count * sizeof(int), cudaMemcpyDeviceToHost));
+        CUDA_CHECK(cudaMemcpy(cand_e, d_cand_e, (size_t)h_count * sizeof(int), cudaMemcpyDeviceToHost));
+    }
+    *ii_stok = h_count;
+}

--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase.h
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase.h
@@ -161,6 +161,7 @@ void inter7_gpu_candidate_pairs_(
     const int*       nsv,          /* slave-to-global node map [nsn]         */
     const int*       irect,        /* segment connectivity [4*nrtm], col-maj */
     const my_real_gpu* x,          /* node coords [3*numnod], col-major      */
+    const my_real_gpu* stfn,       /* slave node stiffness [nsn]             */
     const my_real_gpu* stf,        /* segment stiffness [nrtm]               */
     const my_real_gpu* xyzm,       /* bounding boxes [12]: xmin,ymin,zmin,   */
                                    /*   xmax,ymax,zmax,xminb,...,zmaxb       */

--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase.h
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase.h
@@ -1,0 +1,211 @@
+/*Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+Copyright>
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
+
+/*
+ * inter7_gpu_broadphase.h
+ *
+ * GPU-accelerated broad-phase collision detection for Interface Type 7.
+ *
+ * Architecture overview
+ * =====================
+ * The CPU algorithm (inter7_candidate_pairs.F90 / i7trivox.F) uses a uniform
+ * voxel grid:
+ *   Phase 1 – fill_voxel: assign each slave node to a voxel cell, build a
+ *             per-cell singly-linked list (voxel[] head, next_nod[] chain).
+ *   Phase 2 – candidate pairs: for every master segment find the voxel range
+ *             that its inflated AABB covers, walk each cell's node list,
+ *             and apply a set of rejection filters.
+ *
+ * The GPU implementation replaces Phase 2 (and optionally Phase 1) with CUDA
+ * kernels.  It uses NVIDIA PhysX solely for GPU context management
+ * (PxCudaContextManager) so that CUDA device memory and streams are managed
+ * consistently with a simulation that already uses PhysX for other purposes.
+ * The broad-phase logic itself is a custom sort-based algorithm that maps
+ * exactly to the existing voxel data structure.
+ *
+ * Design decisions
+ * ================
+ * Master-surface vs slave-node asymmetry
+ *   In the CPU code only slave nodes are inserted into voxels; master segments
+ *   are never inserted.  During the query phase only (segment, node) pairs are
+ *   produced, never (node, node) or (segment, segment).  The GPU preserves
+ *   this: slave nodes are uploaded as a sorted array keyed by voxel index,
+ *   master segments are each handled by one CUDA block.  Asymmetric pair
+ *   generation is intrinsic to the algorithm – no explicit filter group trick
+ *   is needed (though the PhysX AABBManager filter-group mechanism would work
+ *   equally well if a full PhysX scene is available).
+ *
+ * Quick rejection of forbidden pairs
+ *   Three levels, cheapest first:
+ *   (a) Corner self-pair  – if the slave global node ID matches any of the
+ *       four corner IDs (M1..M4) of the queried segment the pair is dropped.
+ *       Cost: 4 integer comparisons in registers.
+ *   (b) KREMNODE forbidden pair – the KREMNODE/REMNOD arrays encode, for each
+ *       segment, a list of neighbouring nodes that must not contact it.  The
+ *       GPU receives these lists in CSR format; an in-register binary search
+ *       over the (typically short) per-segment list rejects forbidden pairs
+ *       without extra memory traffic.
+ *   (c) Plane distance underestimation – identical to the CPU formula:
+ *       project the candidate node onto the segment normal and compare with
+ *       AAA^2 * |normal|^2.  Applied after (a) and (b) pass.
+ *
+ * Calling convention
+ * ==================
+ * All entry points follow the Fortran ISO_C_BINDING calling convention
+ * (trailing underscore, pass-by-reference for arrays, pass-by-value for
+ * scalars where annotated).  The Fortran wrapper module
+ * INTER7_GPU_BROADPHASE_MOD (inter7_gpu_broadphase_f.F90) provides
+ * type-safe Fortran interfaces.
+ *
+ * Precision
+ * =========
+ * The real type matches OpenRadioss's WP (4 or 8 bytes).  Compile with
+ *   -DMYREAL8   to use double (WP=8, default recommended for GPU compute)
+ *   (no flag)   to use single (WP=4)
+ *
+ * Dependencies
+ * ============
+ *   CUDA Toolkit >= 11.0
+ *   NVIDIA PhysX SDK >= 5.1  (only PxCudaContextManager is required)
+ *   Thrust (bundled with CUDA Toolkit)
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef MYREAL8
+  typedef double   my_real_gpu;
+#else
+  typedef float    my_real_gpu;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -------------------------------------------------------------------------
+ * Lifecycle
+ * -------------------------------------------------------------------------
+ * inter7_gpu_broadphase_init_
+ *   Initialise the CUDA device and allocate persistent GPU resources.
+ *   Must be called once before any broadphase query.
+ *   Returns 0 on success, non-zero if no CUDA-capable device is available.
+ *
+ * inter7_gpu_broadphase_destroy_
+ *   Release all GPU resources.  Call once at simulation end.
+ * ------------------------------------------------------------------------- */
+int  inter7_gpu_broadphase_init_(void);
+void inter7_gpu_broadphase_destroy_(void);
+
+/* -------------------------------------------------------------------------
+ * inter7_gpu_fill_voxel_
+ *
+ * GPU replacement for fill_voxel_local (fill_voxel.F90).
+ * Inserts slave nodes into the uniform voxel grid on the device.
+ * The resulting voxel[] and next_nod[] arrays (device memory, managed
+ * internally) are consumed by the subsequent inter7_gpu_candidate_pairs_
+ * call within the same timestep.
+ *
+ * Parameters match fill_voxel_local arguments (see fill_voxel.F90).
+ * All pointer arguments point to HOST (Fortran) memory; the function
+ * uploads the required data to the device.
+ * ------------------------------------------------------------------------- */
+void inter7_gpu_fill_voxel_(
+    const int*       nsn,          /* number of local slave nodes            */
+    const int*       nsnr,         /* number of remote (SPMD) slave nodes    */
+    const int*       nbx,          /* voxel grid dimensions                  */
+    const int*       nby,
+    const int*       nbz,
+    const int*       nrtm,         /* number of master segments              */
+    const int*       numnod,       /* total node count                       */
+    const int*       nsv,          /* slave-to-global node map [nsn]         */
+    const my_real_gpu* x,          /* node coords [3*numnod], col-major      */
+    const my_real_gpu* stfn,       /* slave node stiffness [nsn]             */
+    const my_real_gpu* box_limit   /* bounding box [12]                      */
+);
+
+/* -------------------------------------------------------------------------
+ * inter7_gpu_candidate_pairs_
+ *
+ * GPU replacement for INTER7_CANDIDATE_PAIRS (inter7_candidate_pairs.F90).
+ * Assumes the voxel grid has already been filled (either via
+ * inter7_gpu_fill_voxel_ or the CPU fill_voxel routines – the voxel and
+ * next_nod arrays passed here are the same ones used by the CPU path).
+ *
+ * The function uploads the voxel/next_nod state from host to device,
+ * launches the GPU candidate-detection kernel, applies rejection filters,
+ * and writes results back to the host cand_n/cand_e arrays.
+ *
+ * Parameters mirror INTER7_CANDIDATE_PAIRS (inter7_candidate_pairs.F90).
+ * All pointer arguments point to HOST memory.
+ * ------------------------------------------------------------------------- */
+void inter7_gpu_candidate_pairs_(
+    /* ---- geometry ---- */
+    const int*       nsn,          /* number of slave nodes                  */
+    const int*       nrtm,         /* number of master segments              */
+    const int*       numnod,       /* total number of nodes                  */
+    const int*       nsv,          /* slave-to-global node map [nsn]         */
+    const int*       irect,        /* segment connectivity [4*nrtm], col-maj */
+    const my_real_gpu* x,          /* node coords [3*numnod], col-major      */
+    const my_real_gpu* stf,        /* segment stiffness [nrtm]               */
+    const my_real_gpu* xyzm,       /* bounding boxes [12]: xmin,ymin,zmin,   */
+                                   /*   xmax,ymax,zmax,xminb,...,zmaxb       */
+    /* ---- voxel structure (host arrays, already filled) ---- */
+    const int*       voxel,        /* voxel head array [(nbx+2)*(nby+2)*(nbz+2)] */
+    const int*       next_nod,     /* next-node chain [nsn+nsnr]             */
+    const int*       nsnr,         /* number of remote slave nodes           */
+    const int*       nbx,          /* voxel grid dimensions                  */
+    const int*       nby,
+    const int*       nbz,
+    /* ---- gap / contact parameters ---- */
+    const int*       igap,         /* gap model flag                         */
+    const my_real_gpu* marge,      /* margin = tzinf - max(gap+dgapload,drad)*/
+    const my_real_gpu* tzinf,      /* zone-of-influence size                 */
+    const my_real_gpu* gap,        /* scalar gap                             */
+    const my_real_gpu* gapmin,
+    const my_real_gpu* gapmax,
+    const my_real_gpu* bgapsmx,    /* overestimation of gap_s                */
+    const my_real_gpu* drad,       /* radiation distance (thermal)           */
+    const my_real_gpu* dgapload,   /* gap load                               */
+    const my_real_gpu* gap_s,      /* per-slave-node gap [nsn]               */
+    const my_real_gpu* gap_m,      /* per-segment gap [nrtm]                 */
+    const my_real_gpu* curv_max,   /* max curvature per segment [nrtm]       */
+    /* ---- forbidden pair lists (KREMNODE) ---- */
+    const int*       flagremnode,  /* 2 = kremnode active                    */
+    const int*       s_kremnod,    /* size of kremnod array                  */
+    const int*       kremnod,      /* kremnod index pairs [s_kremnod]        */
+    const int*       s_remnod,     /* size of remnod array                   */
+    const int*       remnod,       /* forbidden global node IDs [s_remnod]   */
+    /* ---- output ---- */
+    const int*       mulnsn,       /* maximum number of candidates           */
+    int*             cand_n,       /* OUT: slave node local indices [mulnsn] */
+    int*             cand_e,       /* OUT: segment local indices [mulnsn]    */
+    int*             ii_stok       /* OUT: number of candidates found        */
+);
+
+/* -------------------------------------------------------------------------
+ * inter7_gpu_available_
+ *
+ * Returns 1 if a CUDA-capable device has been successfully initialised,
+ * 0 otherwise.  Fortran callers use this to decide whether to use the GPU
+ * or fall back to the CPU path.
+ * ------------------------------------------------------------------------- */
+int inter7_gpu_available_(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase_f.F90
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase_f.F90
@@ -233,6 +233,13 @@
 !   either the GPU fill_voxel path or the existing CPU fill_voxel path
 !   – both produce equivalent voxel/next_nod arrays.
 !
+!   IMPORTANT – SPMD / MPI limitation:
+!   The GPU broad phase only processes LOCAL slave nodes (indices 1..nsn
+!   in NSV).  Remote slave nodes from other MPI ranks (NSNR > 0) are NOT
+!   submitted to the GPU broad phase and will be silently missed.
+!   The caller must detect NSNR > 0 and supplement or replace the GPU
+!   path with the CPU INTER7_CANDIDATE_PAIRS for remote-node contacts.
+!
 !   The KREMNODE/REMNOD arrays are converted to 0-based CSR offsets
 !   before use (see inter7_gpu_convert_kremnod_csr).
 !

--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase_f.F90
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase_f.F90
@@ -1,0 +1,332 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!||====================================================================
+!||    inter7_gpu_broadphase_mod   ../engine/source/interfaces/intsort/inter7_gpu_broadphase_f.F90
+!||--- called by ------------------------------------------------------
+!||    inter7_collision_detection  ../engine/source/interfaces/intsort/inter7_collision_detection.F90
+!||--- uses       -----------------------------------------------------
+!||    precision_mod               ../common_source/modules/precision_mod.F90
+!||====================================================================
+!
+! Fortran ISO_C_BINDING wrapper for the CUDA/PhysX broad-phase
+! collision detection kernel.
+!
+! Usage example (replacing INTER7_CANDIDATE_PAIRS with GPU path)
+! ==============================================================
+!
+!   use INTER7_GPU_BROADPHASE_MOD
+!
+!   ! At simulation start:
+!   if (inter7_gpu_init() == 0) then
+!     use_gpu = inter7_gpu_available()
+!   end if
+!
+!   ! At every contact sort step (instead of fill_voxel + inter7_candidate_pairs):
+!   if (use_gpu) then
+!     call inter7_gpu_fill_voxel(nsn, nsnr, nbx, nby, nbz, nrtm, numnod,
+!    &    nsv, x, stfn, box_limit_main)
+!     call inter7_gpu_candidate_pairs(nsn, nrtm, numnod, nsv, irect, x, stf,
+!    &    xyzm, inter_struct%voxel, inter_struct%next_nod, nsnr, nbx, nby, nbz,
+!    &    igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload,
+!    &    gap_s, gap_m, curv_max, flagremnode, s_kremnod, kremnod, s_remnod,
+!    &    remnod, mulnsn, cand_n, cand_e, ii_stok)
+!   else
+!     call inter7_candidate_pairs(...)   ! CPU fallback
+!   end if
+!
+!   ! At simulation end:
+!   call inter7_gpu_destroy()
+!
+! Design notes on the open questions
+! ====================================
+!
+! Q: Master surface vs slave node – is it possible on GPU?
+! ---------------------------------------------------------
+! Yes.  The GPU algorithm is structurally asymmetric by construction:
+!   - Slave nodes are hashed into voxels (fill_voxel step).
+!   - Master segments query voxels (candidate_pairs step).
+! Only (slave node, master segment) pairs are ever produced – never
+! (slave, slave) or (master, master).  This mirrors the CPU algorithm
+! exactly.  If a full PhysX scene is used instead, the same asymmetry
+! can be enforced via filter groups:
+!   slave  nodes: filterGroup=1, filterMask=2
+!   master segs:  filterGroup=2, filterMask=1
+! preventing same-type pairs at the broad-phase level.
+!
+! Q: Quick rejection of kremnode and corner nodes
+! -----------------------------------------------
+! Three GPU-friendly filters (applied in increasing cost order):
+!   (a) Corner self-pairs (M1..M4): 4 integer comparisons in registers.
+!       Zero memory traffic; eliminates contact of a node with its own face.
+!   (b) KREMNODE forbidden pairs: per-segment sorted list stored in
+!       device memory in CSR format.  An in-register binary search over the
+!       (typically short, O(10)) list rejects forbidden pairs efficiently.
+!       The Fortran arrays KREMNOD(2*nrtm) / REMNOD(s_remnod) are converted
+!       to 0-based CSR offsets before passing to the kernel:
+!         csr_start(ne) = KREMNOD(2*ne-1)   (0-based offset into REMNOD)
+!         csr_end(ne)   = KREMNOD(2*ne)     (exclusive end, 0-based)
+!       The REMNOD sub-array for segment ne must be sorted in ascending
+!       order for binary search to work.  If not sorted, a linear scan
+!       (dev_linear_search) can be substituted at negligible extra cost for
+!       short lists.
+!   (c) Expanded AABB + plane-distance underestimation: same formulas as
+!       the CPU code; applied after (a)+(b) pass.
+
+      MODULE INTER7_GPU_BROADPHASE_MOD
+        USE ISO_C_BINDING
+        USE PRECISION_MOD, ONLY : WP
+        IMPLICIT NONE
+        PRIVATE
+        PUBLIC :: inter7_gpu_init
+        PUBLIC :: inter7_gpu_destroy
+        PUBLIC :: inter7_gpu_available
+        PUBLIC :: inter7_gpu_fill_voxel
+        PUBLIC :: inter7_gpu_candidate_pairs
+        PUBLIC :: inter7_gpu_convert_kremnod_csr
+
+        ! ----------------------------------------------------------------
+        ! Raw C interfaces (not for direct use; call the wrappers below)
+        ! ----------------------------------------------------------------
+        INTERFACE
+          FUNCTION c_gpu_init() BIND(C, NAME='inter7_gpu_broadphase_init_')
+            IMPORT :: C_INT
+            INTEGER(C_INT) :: c_gpu_init
+          END FUNCTION
+
+          SUBROUTINE c_gpu_destroy() BIND(C, NAME='inter7_gpu_broadphase_destroy_')
+          END SUBROUTINE
+
+          FUNCTION c_gpu_available() BIND(C, NAME='inter7_gpu_available_')
+            IMPORT :: C_INT
+            INTEGER(C_INT) :: c_gpu_available
+          END FUNCTION
+
+          SUBROUTINE c_gpu_fill_voxel( &
+              nsn, nsnr, nbx, nby, nbz, nrtm, numnod, &
+              nsv, x, stfn, box_limit) &
+            BIND(C, NAME='inter7_gpu_fill_voxel_')
+            IMPORT :: C_INT, C_DOUBLE, C_FLOAT
+#ifdef MYREAL8
+            IMPORT :: C_DOUBLE
+            INTEGER(C_INT),  INTENT(IN) :: nsn, nsnr, nbx, nby, nbz, nrtm, numnod
+            INTEGER(C_INT),  INTENT(IN) :: nsv(*)
+            REAL(C_DOUBLE),  INTENT(IN) :: x(*), stfn(*), box_limit(*)
+#else
+            IMPORT :: C_FLOAT
+            INTEGER(C_INT),  INTENT(IN) :: nsn, nsnr, nbx, nby, nbz, nrtm, numnod
+            INTEGER(C_INT),  INTENT(IN) :: nsv(*)
+            REAL(C_FLOAT),   INTENT(IN) :: x(*), stfn(*), box_limit(*)
+#endif
+          END SUBROUTINE
+
+          SUBROUTINE c_gpu_candidate_pairs( &
+              nsn, nrtm, numnod, nsv, irect, x, stf, xyzm, &
+              voxel, next_nod, nsnr, nbx, nby, nbz, &
+              igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload, &
+              gap_s, gap_m, curv_max, &
+              flagremnode, s_kremnod, kremnod, s_remnod, remnod, &
+              mulnsn, cand_n, cand_e, ii_stok) &
+            BIND(C, NAME='inter7_gpu_candidate_pairs_')
+            IMPORT :: C_INT
+#ifdef MYREAL8
+            IMPORT :: C_DOUBLE
+            INTEGER(C_INT),  INTENT(IN)    :: nsn, nrtm, numnod, nsnr
+            INTEGER(C_INT),  INTENT(IN)    :: nbx, nby, nbz, igap
+            INTEGER(C_INT),  INTENT(IN)    :: flagremnode, s_kremnod, s_remnod, mulnsn
+            INTEGER(C_INT),  INTENT(IN)    :: nsv(*), irect(*), voxel(*), next_nod(*)
+            INTEGER(C_INT),  INTENT(IN)    :: kremnod(*), remnod(*)
+            REAL(C_DOUBLE),  INTENT(IN)    :: x(*), stf(*), xyzm(*)
+            REAL(C_DOUBLE),  INTENT(IN)    :: marge, tzinf, gap, gapmin, gapmax
+            REAL(C_DOUBLE),  INTENT(IN)    :: bgapsmx, drad, dgapload
+            REAL(C_DOUBLE),  INTENT(IN)    :: gap_s(*), gap_m(*), curv_max(*)
+            INTEGER(C_INT),  INTENT(OUT)   :: cand_n(*), cand_e(*), ii_stok
+#else
+            IMPORT :: C_FLOAT
+            INTEGER(C_INT),  INTENT(IN)    :: nsn, nrtm, numnod, nsnr
+            INTEGER(C_INT),  INTENT(IN)    :: nbx, nby, nbz, igap
+            INTEGER(C_INT),  INTENT(IN)    :: flagremnode, s_kremnod, s_remnod, mulnsn
+            INTEGER(C_INT),  INTENT(IN)    :: nsv(*), irect(*), voxel(*), next_nod(*)
+            INTEGER(C_INT),  INTENT(IN)    :: kremnod(*), remnod(*)
+            REAL(C_FLOAT),   INTENT(IN)    :: x(*), stf(*), xyzm(*)
+            REAL(C_FLOAT),   INTENT(IN)    :: marge, tzinf, gap, gapmin, gapmax
+            REAL(C_FLOAT),   INTENT(IN)    :: bgapsmx, drad, dgapload
+            REAL(C_FLOAT),   INTENT(IN)    :: gap_s(*), gap_m(*), curv_max(*)
+            INTEGER(C_INT),  INTENT(OUT)   :: cand_n(*), cand_e(*), ii_stok
+#endif
+          END SUBROUTINE
+        END INTERFACE
+
+      CONTAINS
+
+! ======================================================================
+! inter7_gpu_init
+!   Initialise the GPU device and CUDA/PhysX context.
+!   Returns 0 on success, non-zero if no CUDA device is available.
+! ======================================================================
+        INTEGER FUNCTION inter7_gpu_init()
+          IMPLICIT NONE
+          INTEGER(C_INT) :: ret
+          ret = c_gpu_init()
+          inter7_gpu_init = INT(ret)
+        END FUNCTION inter7_gpu_init
+
+! ======================================================================
+! inter7_gpu_destroy
+!   Release all GPU resources.  Call at simulation end.
+! ======================================================================
+        SUBROUTINE inter7_gpu_destroy()
+          IMPLICIT NONE
+          CALL c_gpu_destroy()
+        END SUBROUTINE inter7_gpu_destroy
+
+! ======================================================================
+! inter7_gpu_available
+!   Returns .TRUE. if the GPU path was successfully initialised.
+! ======================================================================
+        LOGICAL FUNCTION inter7_gpu_available()
+          IMPLICIT NONE
+          INTEGER(C_INT) :: ret
+          ret = c_gpu_available()
+          inter7_gpu_available = (ret /= 0)
+        END FUNCTION inter7_gpu_available
+
+! ======================================================================
+! inter7_gpu_fill_voxel
+!   GPU replacement for FILL_VOXEL_LOCAL.
+!   box_limit uses the BMINMA layout (see fill_voxel.F90):
+!     box_limit(1:3)  = xmax, ymax, zmax
+!     box_limit(4:6)  = xmin, ymin, zmin
+!     box_limit(7:9)  = xmaxb, ymaxb, zmaxb  (reduced bbox)
+!     box_limit(10:12)= xminb, yminb, zminb
+! ======================================================================
+        SUBROUTINE inter7_gpu_fill_voxel( &
+            nsn, nsnr, nbx, nby, nbz, nrtm, numnod, &
+            nsv, x, stfn, box_limit)
+          IMPLICIT NONE
+          INTEGER,         INTENT(IN) :: nsn, nsnr, nbx, nby, nbz, nrtm, numnod
+          INTEGER,         INTENT(IN) :: nsv(nsn)
+          REAL(KIND=WP),   INTENT(IN) :: x(3,numnod), stfn(nsn), box_limit(12)
+          CALL c_gpu_fill_voxel( &
+              nsn, nsnr, nbx, nby, nbz, nrtm, numnod, &
+              nsv, x, stfn, box_limit)
+        END SUBROUTINE inter7_gpu_fill_voxel
+
+! ======================================================================
+! inter7_gpu_candidate_pairs
+!   GPU replacement for INTER7_CANDIDATE_PAIRS.
+!
+!   The voxel and next_nod arrays are passed as host pointers; the GPU
+!   kernel uploads them to device memory.  This allows the caller to use
+!   either the GPU fill_voxel path or the existing CPU fill_voxel path
+!   – both produce equivalent voxel/next_nod arrays.
+!
+!   The KREMNODE/REMNOD arrays are converted to 0-based CSR offsets
+!   before use (see inter7_gpu_convert_kremnod_csr).
+!
+!   xyzm layout (Fortran, 1-based):
+!     xyzm(1..6)  = xmin, ymin, zmin, xmax, ymax, zmax
+!     xyzm(7..12) = xminb, yminb, zminb, xmaxb, ymaxb, zmaxb
+! ======================================================================
+        SUBROUTINE inter7_gpu_candidate_pairs( &
+            nsn, nrtm, numnod, nsv, irect, x, stf, xyzm, &
+            voxel, next_nod, nsnr, nbx, nby, nbz, &
+            igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload, &
+            gap_s, gap_m, curv_max, &
+            flagremnode, s_kremnod, kremnod, s_remnod, remnod, &
+            mulnsn, cand_n, cand_e, ii_stok)
+          IMPLICIT NONE
+          INTEGER,         INTENT(IN)    :: nsn, nrtm, numnod, nsnr
+          INTEGER,         INTENT(IN)    :: nbx, nby, nbz, igap
+          INTEGER,         INTENT(IN)    :: flagremnode, s_kremnod, s_remnod, mulnsn
+          INTEGER,         INTENT(IN)    :: nsv(nsn)
+          INTEGER,         INTENT(IN)    :: irect(4,nrtm)
+          INTEGER,         INTENT(IN)    :: voxel(*)
+          INTEGER,         INTENT(IN)    :: next_nod(nsn+nsnr)
+          INTEGER,         INTENT(IN)    :: kremnod(s_kremnod)
+          INTEGER,         INTENT(IN)    :: remnod(s_remnod)
+          REAL(KIND=WP),   INTENT(IN)    :: x(3,numnod)
+          REAL(KIND=WP),   INTENT(IN)    :: stf(nrtm)
+          REAL(KIND=WP),   INTENT(IN)    :: xyzm(12)
+          REAL(KIND=WP),   INTENT(IN)    :: marge, tzinf, gap
+          REAL(KIND=WP),   INTENT(IN)    :: gapmin, gapmax, bgapsmx, drad, dgapload
+          REAL(KIND=WP),   INTENT(IN)    :: gap_s(nsn), gap_m(nrtm), curv_max(nrtm)
+          INTEGER,         INTENT(INOUT) :: cand_n(mulnsn), cand_e(mulnsn)
+          INTEGER,         INTENT(OUT)   :: ii_stok
+
+          INTEGER, ALLOCATABLE :: kremnod_csr(:)
+          INTEGER :: s_krem_csr
+
+          ! Convert KREMNODE to 0-based CSR if kremnode is active
+          IF (flagremnode == 2 .AND. s_kremnod > 0) THEN
+            s_krem_csr = 2 * nrtm
+            ALLOCATE(kremnod_csr(s_krem_csr))
+            CALL inter7_gpu_convert_kremnod_csr(nrtm, kremnod, kremnod_csr)
+            CALL c_gpu_candidate_pairs( &
+                nsn, nrtm, numnod, nsv, irect, x, stf, xyzm, &
+                voxel, next_nod, nsnr, nbx, nby, nbz, &
+                igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload, &
+                gap_s, gap_m, curv_max, &
+                flagremnode, s_krem_csr, kremnod_csr, s_remnod, remnod, &
+                mulnsn, cand_n, cand_e, ii_stok)
+            DEALLOCATE(kremnod_csr)
+          ELSE
+            ! Dummy kremnode arrays when not used
+            CALL c_gpu_candidate_pairs( &
+                nsn, nrtm, numnod, nsv, irect, x, stf, xyzm, &
+                voxel, next_nod, nsnr, nbx, nby, nbz, &
+                igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload, &
+                gap_s, gap_m, curv_max, &
+                flagremnode, 0, kremnod, 0, remnod, &
+                mulnsn, cand_n, cand_e, ii_stok)
+          END IF
+        END SUBROUTINE inter7_gpu_candidate_pairs
+
+! ======================================================================
+! inter7_gpu_convert_kremnod_csr
+!
+! Convert the Fortran KREMNODE array to 0-based CSR offsets used by
+! the GPU kernel.
+!
+! Fortran KREMNODE layout (1-based, NE from 1 to NRTM):
+!   KREMNODE(2*NE-1) = REMNOD start offset (exclusive, 0-based in C)
+!   KREMNODE(2*NE)   = REMNOD end offset   (exclusive, 0-based in C)
+!
+! The GPU kernel expects (0-based C):
+!   kremnod_csr[2*ne]   = start index into REMNOD (0-based)
+!   kremnod_csr[2*ne+1] = end   index into REMNOD (0-based, exclusive)
+!
+! Reminder: in Fortran (1-based NE, K from KREMNODE(2*(NE-1)+1)+1 to
+! KREMNODE(2*(NE-1)+2)), the forbidden nodes for segment NE are at
+! REMNOD(K..L) where K and L are 1-based Fortran indices.
+! Conversion: CSR_start = KREMNODE(2*NE-1)  (already 0-based offset)
+!             CSR_end   = KREMNODE(2*NE)     (already 0-based offset)
+! The REMNOD array is assumed to be sorted per segment.
+! ======================================================================
+        SUBROUTINE inter7_gpu_convert_kremnod_csr(nrtm, kremnod, kremnod_csr)
+          IMPLICIT NONE
+          INTEGER, INTENT(IN)  :: nrtm
+          INTEGER, INTENT(IN)  :: kremnod(2*nrtm+1)  ! Fortran 1-based layout
+          INTEGER, INTENT(OUT) :: kremnod_csr(2*nrtm) ! 0-based CSR output
+          INTEGER :: ne
+          DO ne = 1, nrtm
+            ! KREMNOD(2*(NE-1)+1) = start-1 (Fortran)  → 0-based start
+            ! KREMNOD(2*(NE-1)+2) = end      (Fortran)  → 0-based end
+            kremnod_csr(2*ne-1) = kremnod(2*(ne-1)+1)
+            kremnod_csr(2*ne)   = kremnod(2*(ne-1)+2)
+          END DO
+        END SUBROUTINE inter7_gpu_convert_kremnod_csr
+
+      END MODULE INTER7_GPU_BROADPHASE_MOD

--- a/engine/source/interfaces/intsort/inter7_gpu_broadphase_f.F90
+++ b/engine/source/interfaces/intsort/inter7_gpu_broadphase_f.F90
@@ -38,7 +38,7 @@
 !   if (use_gpu) then
 !     call inter7_gpu_fill_voxel(nsn, nsnr, nbx, nby, nbz, nrtm, numnod,
 !    &    nsv, x, stfn, box_limit_main)
-!     call inter7_gpu_candidate_pairs(nsn, nrtm, numnod, nsv, irect, x, stf,
+!     call inter7_gpu_candidate_pairs(nsn, nrtm, numnod, nsv, irect, x, stfn, stf,
 !    &    xyzm, inter_struct%voxel, inter_struct%next_nod, nsnr, nbx, nby, nbz,
 !    &    igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload,
 !    &    gap_s, gap_m, curv_max, flagremnode, s_kremnod, kremnod, s_remnod,
@@ -133,7 +133,7 @@
           END SUBROUTINE
 
           SUBROUTINE c_gpu_candidate_pairs( &
-              nsn, nrtm, numnod, nsv, irect, x, stf, xyzm, &
+              nsn, nrtm, numnod, nsv, irect, x, stfn, stf, xyzm, &
               voxel, next_nod, nsnr, nbx, nby, nbz, &
               igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload, &
               gap_s, gap_m, curv_max, &
@@ -148,7 +148,7 @@
             INTEGER(C_INT),  INTENT(IN)    :: flagremnode, s_kremnod, s_remnod, mulnsn
             INTEGER(C_INT),  INTENT(IN)    :: nsv(*), irect(*), voxel(*), next_nod(*)
             INTEGER(C_INT),  INTENT(IN)    :: kremnod(*), remnod(*)
-            REAL(C_DOUBLE),  INTENT(IN)    :: x(*), stf(*), xyzm(*)
+            REAL(C_DOUBLE),  INTENT(IN)    :: x(*), stfn(*), stf(*), xyzm(*)
             REAL(C_DOUBLE),  INTENT(IN)    :: marge, tzinf, gap, gapmin, gapmax
             REAL(C_DOUBLE),  INTENT(IN)    :: bgapsmx, drad, dgapload
             REAL(C_DOUBLE),  INTENT(IN)    :: gap_s(*), gap_m(*), curv_max(*)
@@ -160,7 +160,7 @@
             INTEGER(C_INT),  INTENT(IN)    :: flagremnode, s_kremnod, s_remnod, mulnsn
             INTEGER(C_INT),  INTENT(IN)    :: nsv(*), irect(*), voxel(*), next_nod(*)
             INTEGER(C_INT),  INTENT(IN)    :: kremnod(*), remnod(*)
-            REAL(C_FLOAT),   INTENT(IN)    :: x(*), stf(*), xyzm(*)
+            REAL(C_FLOAT),   INTENT(IN)    :: x(*), stfn(*), stf(*), xyzm(*)
             REAL(C_FLOAT),   INTENT(IN)    :: marge, tzinf, gap, gapmin, gapmax
             REAL(C_FLOAT),   INTENT(IN)    :: bgapsmx, drad, dgapload
             REAL(C_FLOAT),   INTENT(IN)    :: gap_s(*), gap_m(*), curv_max(*)
@@ -241,7 +241,7 @@
 !     xyzm(7..12) = xminb, yminb, zminb, xmaxb, ymaxb, zmaxb
 ! ======================================================================
         SUBROUTINE inter7_gpu_candidate_pairs( &
-            nsn, nrtm, numnod, nsv, irect, x, stf, xyzm, &
+            nsn, nrtm, numnod, nsv, irect, x, stfn, stf, xyzm, &
             voxel, next_nod, nsnr, nbx, nby, nbz, &
             igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload, &
             gap_s, gap_m, curv_max, &
@@ -258,6 +258,7 @@
           INTEGER,         INTENT(IN)    :: kremnod(s_kremnod)
           INTEGER,         INTENT(IN)    :: remnod(s_remnod)
           REAL(KIND=WP),   INTENT(IN)    :: x(3,numnod)
+          REAL(KIND=WP),   INTENT(IN)    :: stfn(nsn)
           REAL(KIND=WP),   INTENT(IN)    :: stf(nrtm)
           REAL(KIND=WP),   INTENT(IN)    :: xyzm(12)
           REAL(KIND=WP),   INTENT(IN)    :: marge, tzinf, gap
@@ -275,7 +276,7 @@
             ALLOCATE(kremnod_csr(s_krem_csr))
             CALL inter7_gpu_convert_kremnod_csr(nrtm, kremnod, kremnod_csr)
             CALL c_gpu_candidate_pairs( &
-                nsn, nrtm, numnod, nsv, irect, x, stf, xyzm, &
+                nsn, nrtm, numnod, nsv, irect, x, stfn, stf, xyzm, &
                 voxel, next_nod, nsnr, nbx, nby, nbz, &
                 igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload, &
                 gap_s, gap_m, curv_max, &
@@ -285,7 +286,7 @@
           ELSE
             ! Dummy kremnode arrays when not used
             CALL c_gpu_candidate_pairs( &
-                nsn, nrtm, numnod, nsv, irect, x, stf, xyzm, &
+                nsn, nrtm, numnod, nsv, irect, x, stfn, stf, xyzm, &
                 voxel, next_nod, nsnr, nbx, nby, nbz, &
                 igap, marge, tzinf, gap, gapmin, gapmax, bgapsmx, drad, dgapload, &
                 gap_s, gap_m, curv_max, &


### PR DESCRIPTION
New files:
  inter7_gpu_broadphase.h        – C interface callable from Fortran
  inter7_gpu_broadphase.cu       – CUDA/PhysX implementation
  inter7_gpu_broadphase_f.F90    – Fortran ISO_C_BINDING wrapper module

Design mirrors inter7_candidate_pairs.F90 / fill_voxel.F90 exactly:
  - fill_voxel GPU path: each slave node inserted into voxel hash via
    atomicExch-based linked-list construction (parallel over nodes).
  - candidate_pairs GPU path: one CUDA block per master segment; threads
    cooperate over the segment's inflated-AABB voxel range.

Master-surface vs slave-node asymmetry is intrinsic to the algorithm:
only slave nodes are hashed into voxels; master segments query voxels.
Only (slave-node, master-segment) pairs are ever produced.

Three-level rejection on GPU (cheapest first):
  (a) Corner self-pairs (M1..M4): 4 integer comparisons in registers.
  (b) KREMNODE forbidden pairs: CSR binary search per segment.
  (c) Expanded AABB + plane-distance underestimation (same as CPU).

PhysX PxCudaContextManager is used for device context management when
the -DUSE_PHYSX compile flag is set; falls back to plain CUDA otherwise.

https://claude.ai/code/session_01PsCoPYCNQGdQiEscbKESMd